### PR TITLE
Disable automatic broken-link checks

### DIFF
--- a/.github/workflows/broken-links-site.yml
+++ b/.github/workflows/broken-links-site.yml
@@ -1,9 +1,10 @@
 name: Check for broken links on site
 
+# Broken-link checking is intentionally disabled.
+# Keep this workflow manual-only so the configuration remains available
+# without blocking pushes, pull requests, or deploys.
 on:
-  workflow_run:
-    workflows: [Deploy site]
-    types: [completed]
+  workflow_dispatch:
 
 jobs:
   check-links-on-site:

--- a/.github/workflows/broken-links.yml
+++ b/.github/workflows/broken-links.yml
@@ -1,42 +1,10 @@
 name: Check for broken links
 
+# Broken-link checking is intentionally disabled.
+# Keep this workflow manual-only so the configuration remains available
+# without blocking pushes, pull requests, or deploys.
 on:
-  push:
-    branches:
-      - master
-      - main
-    paths:
-      - "assets/**"
-      - "**.html"
-      - "**.js"
-      - "**.liquid"
-      - "**/*.md"
-      - "**.yml"
-      - "!.github/workflows/axe.yml"
-      - "!.github/workflows/deploy-docker-tag.yml"
-      - "!.github/workflows/deploy-image.yml"
-      - "!.github/workflows/docker-slim.yml"
-      - "!.github/workflows/lighthouse-badger.yml"
-      - "!.github/workflows/prettier.yml"
-      - "!lighthouse_results/**"
-  pull_request:
-    branches:
-      - master
-      - main
-    paths:
-      - "assets/**"
-      - "**.html"
-      - "**.js"
-      - "**.liquid"
-      - "**/*.md"
-      - "**.yml"
-      - "!.github/workflows/axe.yml"
-      - "!.github/workflows/deploy-docker-tag.yml"
-      - "!.github/workflows/deploy-image.yml"
-      - "!.github/workflows/docker-slim.yml"
-      - "!.github/workflows/lighthouse-badger.yml"
-      - "!.github/workflows/prettier.yml"
-      - "!lighthouse_results/**"
+  workflow_dispatch:
 
 jobs:
   link-checker:


### PR DESCRIPTION
Stop the broken-link workflows from running automatically on push/PR/deploy.

- `.github/workflows/broken-links.yml` and `.github/workflows/broken-links-site.yml` are switched to `workflow_dispatch` only (manual trigger).
- The lychee configuration is preserved so the checks can still be run on demand.

Requested by Fan: stop the broken-link checking. Opened for review.