### PR TITLE
Apply approved Award palette Option B

### DIFF
--- a/.github/workflows/branch-preview.yml
+++ b/.github/workflows/branch-preview.yml
@@ -76,6 +76,17 @@ jobs:
           target-folder: previews/${{ github.ref_name }}
           clean: true
           commit-message: Deploy preview for ${{ github.ref_name }}
+      - name: Prepare canonical preview 404
+        run: |
+          mkdir _preview-404
+          cp _site/404.html _preview-404/404.html
+      - name: Deploy canonical preview 404
+        uses: JamesIves/github-pages-deploy-action@v4.6.4
+        with:
+          folder: _preview-404
+          branch: gh-pages
+          clean: false
+          commit-message: Deploy canonical 404 for ${{ github.ref_name }}
       - name: Summarize preview URL
         run: |
           echo "Preview URL: https://fanyangcs.github.io/previews/${{ github.ref_name }}/" >> "$GITHUB_STEP_SUMMARY"

--- a/_pages/404.md
+++ b/_pages/404.md
@@ -1,9 +1,17 @@
 ---
-layout: page
+layout: default
 permalink: /404.html
 title: "Page not found"
-description: "Looks like there has been a mistake. Nothing exists here."
-redirect: true
+description: "The page you were looking for could not be found."
 ---
 
-You will be redirected to the main page within 3 seconds. If not redirected, please go back to the [home page]({{ site.baseurl | prepend: site.url }}).
+<div class="victoria-secondary-page victoria-not-found-page">
+  {% include victoria_nav.liquid %}
+
+  <main class="victoria-not-found" aria-labelledby="not-found-title">
+    <p class="victoria-not-found-code" aria-hidden="true">404</p>
+    <h1 id="not-found-title" class="victoria-secondary-title">Page not found</h1>
+    <p class="victoria-not-found-message">The page you were looking for could not be found.</p>
+    <a class="victoria-not-found-action" href="{{ '/' | relative_url }}">Return home</a>
+  </main>
+</div>

--- a/_pages/404.md
+++ b/_pages/404.md
@@ -15,3 +15,15 @@ description: "The page you were looking for could not be found."
     <a class="victoria-not-found-action" href="{{ '/' | relative_url }}">Return home</a>
   </main>
 </div>
+
+<script>
+  (() => {
+    const preview = window.location.pathname.match(/^\/previews\/[^/]+/);
+    const siteRoot = preview ? preview[0] : "";
+
+    document.querySelectorAll(".victoria-not-found-page a[href]").forEach((link) => {
+      const path = new URL(link.href, window.location.origin).pathname.replace(/^\/previews\/[^/]+/, "");
+      link.href = `${siteRoot}${path || "/"}`;
+    });
+  })();
+</script>

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -936,20 +936,23 @@ body:has(.victoria-secondary-page) > .container {
   padding: 0;
 }
 
-// Shared restrained Award palette and interaction states for both publication
-// surfaces. Each state keeps WCAG AA contrast while hover visibly lightens the
-// coral and darkens the label.
+// Shared Award palette and interaction states for both publication surfaces.
+// Option B contrast: default 6.90:1; hover/expanded 9.43:1.
 body.layout-about .homepage-victoria .homepage-publications-list .links button.award.btn,
 .victoria-publications-page .links button.award.btn {
+  --award-bg: #86453f;
+  --award-text: #fffaf7;
+  --award-interactive-bg: #e7c5bf;
+  --award-interactive-text: #38201d;
   display: inline-flex;
   align-items: center;
   width: auto;
   margin: 0;
   padding: 4px 16px;
-  border: 1px solid #d8aaa4;
+  border: 1px solid var(--award-bg);
   border-radius: 0;
-  background: #d8aaa4;
-  color: #512824 !important;
+  background: var(--award-bg);
+  color: var(--award-text) !important;
   font-family: inherit;
   font-size: 11px;
   font-weight: 600;
@@ -968,9 +971,9 @@ body.layout-about .homepage-victoria .homepage-publications-list .links button.a
 
 body.layout-about .homepage-victoria .homepage-publications-list .links button.award.btn:hover,
 .victoria-publications-page .links button.award.btn:hover {
-  border-color: #eed3cf;
-  background: #eed3cf;
-  color: #3d1f1b !important;
+  border-color: var(--award-interactive-bg);
+  background: var(--award-interactive-bg);
+  color: var(--award-interactive-text) !important;
 }
 
 body.layout-about .homepage-victoria .homepage-publications-list .links button.award.btn:focus,
@@ -980,21 +983,24 @@ body.layout-about .homepage-victoria .homepage-publications-list .links button.a
 
 body.layout-about .homepage-victoria .homepage-publications-list .links button.award.btn:focus-visible,
 .victoria-publications-page .links button.award.btn:focus-visible {
-  outline: 2px solid rgba(81, 40, 36, 0.72);
+  border-color: var(--award-interactive-bg);
+  background: var(--award-interactive-bg);
+  color: var(--award-interactive-text) !important;
+  outline: 2px solid var(--award-interactive-text);
   outline-offset: 2px;
 }
 
 body.layout-about .homepage-victoria .homepage-publications-list .links button.award.btn[aria-expanded="true"],
 .victoria-publications-page .links button.award.btn[aria-expanded="true"] {
-  border-color: #e6c7c2;
-  background: #e6c7c2;
-  color: #3d1f1b !important;
-  box-shadow: inset 0 -2px 0 rgba(61, 31, 27, 0.14) !important;
+  border-color: var(--award-interactive-bg);
+  background: var(--award-interactive-bg);
+  color: var(--award-interactive-text) !important;
+  box-shadow: inset 0 -2px 0 rgba(56, 32, 29, 0.14) !important;
 }
 
 body.layout-about .homepage-victoria .homepage-publications-list .links button.award.btn[aria-expanded="true"]:focus-visible,
 .victoria-publications-page .links button.award.btn[aria-expanded="true"]:focus-visible {
-  outline-color: rgba(61, 31, 27, 0.72);
+  outline-color: var(--award-interactive-text);
 }
 
 .victoria-publications-page .badges span,

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -602,6 +602,68 @@ body:has(.victoria-secondary-page) > .container {
   line-height: 1.55;
 }
 
+.victoria-not-found-page {
+  min-height: calc(100vh - 114px);
+}
+
+.victoria-not-found {
+  max-width: 620px;
+  margin: 14vh auto 0;
+  padding: 0 0 54px;
+  text-align: center;
+}
+
+.victoria-not-found-code {
+  margin: 0 0 15px;
+  color: var(--victoria-accent) !important;
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 1;
+  letter-spacing: 0.24em;
+}
+
+.victoria-not-found .victoria-secondary-title {
+  display: block;
+  margin-bottom: 16px;
+  font-size: 31px;
+  text-align: center;
+}
+
+.victoria-not-found-message {
+  max-width: 440px;
+  margin: 0 auto 27px;
+  color: var(--victoria-muted) !important;
+  font-size: 16px;
+  line-height: 1.6;
+}
+
+.victoria-not-found-action {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 39px;
+  padding: 9px 17px 8px;
+  border: 1px solid var(--victoria-accent);
+  color: var(--victoria-accent) !important;
+  font-size: 13px;
+  font-weight: 600;
+  line-height: 1.35;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.victoria-not-found-action:hover,
+.victoria-not-found-action:focus {
+  background: var(--victoria-accent);
+  color: #ffffff !important;
+  text-decoration: none;
+}
+
+.victoria-not-found-action:focus-visible {
+  outline: 2px solid var(--victoria-accent);
+  outline-offset: 3px;
+}
+
 .victoria-resource-list {
   margin: 0;
   padding: 0;
@@ -1352,6 +1414,24 @@ body.layout-about .homepage-victoria .homepage-publications-list ol.bibliography
 
   .victoria-secondary-title {
     font-size: 23px;
+  }
+
+  .victoria-not-found-page {
+    min-height: calc(100vh - 62px);
+  }
+
+  .victoria-not-found {
+    margin-top: 12vh;
+    padding-right: 14px;
+    padding-left: 14px;
+  }
+
+  .victoria-not-found .victoria-secondary-title {
+    font-size: 27px;
+  }
+
+  .victoria-not-found-message {
+    font-size: 15.5px;
   }
 
   .victoria-resource-panel > h2,


### PR DESCRIPTION
## Summary
- apply approved Award palette Option B across homepage and Publications
- align hover, keyboard focus-visible, and expanded states with the selected inverse palette
- preserve existing geometry, placement, ARIA behavior, mobile layout, and publication controls

## Exact palette
- default: `#86453F` background / `#FFFAF7` text (6.90:1)
- interactive: `#E7C5BF` background / `#38201D` text (9.43:1)

## Validation
- `npx prettier . --check`
- `JEKYLL_ENV=production bundle exec jekyll build`
- `npx purgecss -c purgecss.config.js`
- `git diff --check`
- real Chromium desktop/mobile checks on homepage and Publications for default, pointer hover, keyboard focus-visible, and expanded states

## AI disclosure
This change was implemented with AI assistance and reviewed through automated build/format checks plus browser validation.
