### PR TITLE
Fix canonical 404 navigation and browser title

### DIFF
--- a/_includes/victoria_nav.liquid
+++ b/_includes/victoria_nav.liquid
@@ -1,34 +1,48 @@
+{% if include.canonical_nav %}
+  {% assign home_url = '/' %}
+  {% assign blog_url = '/blog/' %}
+  {% assign news_url = '/news/' %}
+  {% assign publications_url = '/publications/' %}
+  {% assign projects_url = '/projects/' %}
+{% else %}
+  {% assign home_url = '/' | relative_url %}
+  {% assign blog_url = '/blog/' | relative_url %}
+  {% assign news_url = '/news/' | relative_url %}
+  {% assign publications_url = '/publications/' | relative_url %}
+  {% assign projects_url = '/projects/' | relative_url %}
+{% endif %}
+
 <nav class="victoria-secondary-nav" aria-label="Site navigation">
   <a
-    href="{{ '/' | relative_url }}"
+    href="{{ home_url }}"
     {% if include.current == 'about' %}
       aria-current="page"
     {% endif %}
     >About</a
   >
   <a
-    href="{{ '/blog/' | relative_url }}"
+    href="{{ blog_url }}"
     {% if include.current == 'blog' %}
       aria-current="page"
     {% endif %}
     >Blog</a
   >
   <a
-    href="{{ '/news/' | relative_url }}"
+    href="{{ news_url }}"
     {% if include.current == 'news' %}
       aria-current="page"
     {% endif %}
     >News</a
   >
   <a
-    href="{{ '/publications/' | relative_url }}"
+    href="{{ publications_url }}"
     {% if include.current == 'publications' %}
       aria-current="page"
     {% endif %}
     >Publications</a
   >
   <a
-    href="{{ '/projects/' | relative_url }}"
+    href="{{ projects_url }}"
     {% if include.current == 'projects' %}
       aria-current="page"
     {% endif %}
@@ -42,10 +56,10 @@
     <span class="homepage-menu-icon" aria-hidden="true"><span></span><span></span><span></span></span>
   </summary>
   <nav class="homepage-mobile-menu-panel" aria-label="Site navigation">
-    <a href="{{ '/' | relative_url }}">About</a>
-    <a href="{{ '/blog/' | relative_url }}">Blog</a>
-    <a href="{{ '/news/' | relative_url }}">News</a>
-    <a href="{{ '/publications/' | relative_url }}">Publications</a>
-    <a href="{{ '/projects/' | relative_url }}">Projects</a>
+    <a href="{{ home_url }}">About</a>
+    <a href="{{ blog_url }}">Blog</a>
+    <a href="{{ news_url }}">News</a>
+    <a href="{{ publications_url }}">Publications</a>
+    <a href="{{ projects_url }}">Projects</a>
   </nav>
 </details>

--- a/_pages/404.md
+++ b/_pages/404.md
@@ -2,28 +2,17 @@
 layout: default
 permalink: /404.html
 title: "Page not found"
+browser_title: "Page Not Found"
 description: "The page you were looking for could not be found."
 ---
 
 <div class="victoria-secondary-page victoria-not-found-page">
-  {% include victoria_nav.liquid %}
+  {% include victoria_nav.liquid canonical_nav=true %}
 
   <main class="victoria-not-found" aria-labelledby="not-found-title">
     <p class="victoria-not-found-code" aria-hidden="true">404</p>
     <h1 id="not-found-title" class="victoria-secondary-title">Page not found</h1>
     <p class="victoria-not-found-message">The page you were looking for could not be found.</p>
-    <a class="victoria-not-found-action" href="{{ '/' | relative_url }}">Return home</a>
+    <a class="victoria-not-found-action" href="/">Return home</a>
   </main>
 </div>
-
-<script>
-  (() => {
-    const preview = window.location.pathname.match(/^\/previews\/[^/]+/);
-    const siteRoot = preview ? preview[0] : "";
-
-    document.querySelectorAll(".victoria-not-found-page a[href]").forEach((link) => {
-      const path = new URL(link.href, window.location.origin).pathname.replace(/^\/previews\/[^/]+/, "");
-      link.href = `${siteRoot}${path || "/"}`;
-    });
-  })();
-</script>


### PR DESCRIPTION
## Summary
- make the shared 404 navigation and Return home link resolve to canonical production-root URLs at every requested path depth
- keep normal Victoria navigation preview-aware by opting into canonical links only from the 404 page
- set the browser title exactly to `Fan Yang - Page Not Found`
- remove the old client-side preview-prefix rewriting without changing the approved 404 styling or Award Option B palette

## Validation
- `npx prettier . --check`
- production Jekyll build (`baseurl: ""`)
- branch-preview Jekyll build (`baseurl: "/previews/fix-404-canonical-links"`)
- PurgeCSS against both builds
- inspected both built `404.html` files: desktop/mobile nav hrefs are `/`, `/blog/`, `/news/`, `/publications/`, `/projects/`; Return home is `/`; title is exact
- `git diff --check`

AI-assisted implementation and verification.
