### PR TITLE
Redesign News as title-first editorial list

### DIFF
--- a/_includes/news_page.liquid
+++ b/_includes/news_page.liquid
@@ -1,0 +1,37 @@
+{% assign news = site.news | sort: 'date' | reverse %}
+{% assign per_page = 5 %}
+{% assign offset = include.page_number | minus: 1 | times: per_page %}
+{% assign page_news = news | slice: offset, per_page %}
+
+<div class="victoria-secondary-page victoria-news-page">
+  {% include victoria_nav.liquid current="news" %}
+
+  <h1 class="victoria-secondary-title">News</h1>
+
+  {% if page_news != blank %}
+    <div class="victoria-resource-list victoria-news-list">
+      {% for item in page_news %}
+        <article class="victoria-resource-panel victoria-news-item">
+          <h2>
+            {% if item.inline %}
+              <span>{{ item.title }}</span>
+            {% else %}
+              <a class="news-title" href="{{ item.url | relative_url }}">{{ item.title }}</a>
+            {% endif %}
+          </h2>
+          <p class="victoria-news-meta">
+            <time datetime="{{ item.date | date: '%Y-%m-%d' }}">{{ item.date | date: '%B %d, %Y' }}</time>
+          </p>
+        </article>
+      {% endfor %}
+    </div>
+  {% else %}
+    <p>No news so far...</p>
+  {% endif %}
+
+  <div class="victoria-pagination">
+    {% include news_pagination.liquid current_page=include.page_number %}
+  </div>
+
+  <p class="victoria-back-link"><a href="{{ '/' | relative_url }}">&larr; Back</a></p>
+</div>

--- a/_includes/news_pagination.liquid
+++ b/_includes/news_pagination.liquid
@@ -1,0 +1,35 @@
+<nav aria-label="News page navigation">
+  <ul class="pagination pagination-lg justify-content-center">
+    <li class="page-item {% if include.current_page == 1 %}disabled{% endif %}">
+      {% if include.current_page == 1 %}
+        <span class="page-link" aria-disabled="true">Newer</span>
+      {% elsif include.current_page == 2 %}
+        <a class="page-link" href="{{ '/news/' | relative_url }}" rel="prev">Newer</a>
+      {% else %}
+        {% assign previous_page = include.current_page | minus: 1 %}
+        <a class="page-link" href="{{ '/news/page/' | append: previous_page | append: '/' | relative_url }}" rel="prev">Newer</a>
+      {% endif %}
+    </li>
+    {% for page_number in (1..3) %}
+      <li class="page-item {% if include.current_page == page_number %}active{% endif %}">
+        {% if include.current_page == page_number %}
+          <span class="page-link" aria-current="page">{{ page_number }}</span>
+        {% elsif page_number == 1 %}
+          <a class="page-link" href="{{ '/news/' | relative_url }}" title="News page 1">{{ page_number }}</a>
+        {% else %}
+          <a class="page-link" href="{{ '/news/page/' | append: page_number | append: '/' | relative_url }}" title="News page {{ page_number }}">
+            {{- page_number -}}
+          </a>
+        {% endif %}
+      </li>
+    {% endfor %}
+    <li class="page-item {% if include.current_page == 3 %}disabled{% endif %}">
+      {% if include.current_page == 3 %}
+        <span class="page-link" aria-disabled="true">Older</span>
+      {% else %}
+        {% assign next_page = include.current_page | plus: 1 %}
+        <a class="page-link" href="{{ '/news/page/' | append: next_page | append: '/' | relative_url }}" rel="next">Older</a>
+      {% endif %}
+    </li>
+  </ul>
+</nav>

--- a/_pages/news.md
+++ b/_pages/news.md
@@ -16,19 +16,19 @@ nav_order: 2
 {% if site.news != blank %}
 {% assign news = site.news | reverse %}
 
-<div class="victoria-resource-list">
+<div class="victoria-resource-list victoria-news-list">
 {% for item in news %}
 <article class="victoria-resource-panel victoria-news-item">
 <h2>
-<time datetime="{{ item.date | date: '%Y-%m-%d' }}">{{ item.date | date: '%b %d, %Y' }}</time>
-</h2>
-<div class="victoria-resource-copy">
 {% if item.inline %}
-{{ item.content | remove: '<p>' | remove: '</p>' | emojify }}
+<span>{{ item.title }}</span>
 {% else %}
 <a class="news-title" href="{{ item.url | relative_url }}">{{ item.title }}</a>
 {% endif %}
-</div>
+</h2>
+<p class="victoria-news-meta">
+<time datetime="{{ item.date | date: '%Y-%m-%d' }}">{{ item.date | date: '%B %d, %Y' }}</time>
+</p>
 </article>
 {% endfor %}
 </div>

--- a/_pages/news.md
+++ b/_pages/news.md
@@ -8,33 +8,4 @@ nav: true
 nav_order: 2
 ---
 
-<div class="victoria-secondary-page victoria-news-page">
-  {% include victoria_nav.liquid current="news" %}
-
-  <h1 class="victoria-secondary-title">News</h1>
-
-{% if site.news != blank %}
-{% assign news = site.news | reverse %}
-
-<div class="victoria-resource-list victoria-news-list">
-{% for item in news %}
-<article class="victoria-resource-panel victoria-news-item">
-<h2>
-{% if item.inline %}
-<span>{{ item.title }}</span>
-{% else %}
-<a class="news-title" href="{{ item.url | relative_url }}">{{ item.title }}</a>
-{% endif %}
-</h2>
-<p class="victoria-news-meta">
-<time datetime="{{ item.date | date: '%Y-%m-%d' }}">{{ item.date | date: '%B %d, %Y' }}</time>
-</p>
-</article>
-{% endfor %}
-</div>
-{% else %}
-<p>No news so far...</p>
-{% endif %}
-
-  <p class="victoria-back-link"><a href="{{ '/' | relative_url }}">&larr; Back</a></p>
-</div>
+{% include news_page.liquid page_number=1 %}

--- a/_pages/news/page-2.md
+++ b/_pages/news/page-2.md
@@ -1,0 +1,9 @@
+---
+layout: default
+title: news
+browser_title: News — Page 2
+permalink: /news/page/2/
+sitemap: false
+---
+
+{% include news_page.liquid page_number=2 %}

--- a/_pages/news/page-3.md
+++ b/_pages/news/page-3.md
@@ -1,0 +1,9 @@
+---
+layout: default
+title: news
+browser_title: News — Page 3
+permalink: /news/page/3/
+sitemap: false
+---
+
+{% include news_page.liquid page_number=3 %}

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -767,17 +767,20 @@ body:has(.victoria-secondary-page) > .container {
   text-transform: uppercase;
 }
 
-.victoria-blog-page .victoria-pagination {
+.victoria-blog-page .victoria-pagination,
+.victoria-news-page .victoria-pagination {
   margin-top: 24px;
 }
 
-.victoria-blog-page .victoria-pagination .pagination {
+.victoria-blog-page .victoria-pagination .pagination,
+.victoria-news-page .victoria-pagination .pagination {
   gap: 8px;
   justify-content: flex-start;
   margin: 0;
 }
 
-.victoria-blog-page .victoria-pagination .page-link {
+.victoria-blog-page .victoria-pagination .page-link,
+.victoria-news-page .victoria-pagination .page-link {
   min-width: 34px;
   padding: 6px 10px;
   border: 1px solid var(--victoria-faint) !important;
@@ -794,7 +797,9 @@ body:has(.victoria-secondary-page) > .container {
 }
 
 .victoria-blog-page .victoria-pagination .page-link:hover,
-.victoria-blog-page .victoria-pagination .page-link:focus {
+.victoria-blog-page .victoria-pagination .page-link:focus,
+.victoria-news-page .victoria-pagination .page-link:hover,
+.victoria-news-page .victoria-pagination .page-link:focus {
   border-color: var(--victoria-rule) !important;
   background: transparent !important;
   box-shadow: none !important;
@@ -804,13 +809,17 @@ body:has(.victoria-secondary-page) > .container {
 
 .victoria-blog-page .victoria-pagination .page-item.active .page-link,
 .victoria-blog-page .victoria-pagination .page-item.active .page-link:hover,
-.victoria-blog-page .victoria-pagination .page-item.active .page-link:focus {
+.victoria-blog-page .victoria-pagination .page-item.active .page-link:focus,
+.victoria-news-page .victoria-pagination .page-item.active .page-link,
+.victoria-news-page .victoria-pagination .page-item.active .page-link:hover,
+.victoria-news-page .victoria-pagination .page-item.active .page-link:focus {
   border-color: var(--victoria-accent) !important;
   background: transparent !important;
   color: var(--victoria-ink) !important;
 }
 
-.victoria-blog-page .victoria-pagination .page-item.disabled .page-link {
+.victoria-blog-page .victoria-pagination .page-item.disabled .page-link,
+.victoria-news-page .victoria-pagination .page-item.disabled .page-link {
   border-color: var(--victoria-faint) !important;
   background: transparent !important;
   color: var(--victoria-muted) !important;

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -717,11 +717,43 @@ body:has(.victoria-secondary-page) > .container {
   margin: 0 0 6px;
 }
 
-.victoria-news-item time {
-  color: var(--victoria-ink);
-  font-size: 17px;
+.victoria-news-list .victoria-news-item {
+  padding: 26px 0 24px;
+}
+
+.victoria-news-list .victoria-news-item:first-child {
+  padding-top: 9px;
+}
+
+.victoria-news-list .victoria-news-item > h2 {
+  gap: 13px;
+  margin-bottom: 10px;
+  font-size: 22px;
+  line-height: 1.31;
+  letter-spacing: -0.006em;
+}
+
+.victoria-news-list .victoria-news-item > h2::before {
+  width: 8px;
+  height: 8px;
+}
+
+.victoria-news-list .victoria-news-item > h2 a {
+  color: var(--victoria-accent);
+}
+
+.victoria-news-meta {
+  margin: 0 0 0 21px;
+  color: var(--victoria-muted) !important;
+  font-size: 13px;
   font-weight: 600;
-  line-height: 1.32;
+  line-height: 1.35;
+  letter-spacing: 0.07em;
+  text-transform: uppercase;
+}
+
+.victoria-news-meta time {
+  color: inherit;
 }
 
 .victoria-post-meta {
@@ -1434,9 +1466,17 @@ body.layout-about .homepage-victoria .homepage-publications-list ol.bibliography
     font-size: 15.5px;
   }
 
-  .victoria-resource-panel > h2,
-  .victoria-news-item time {
+  .victoria-resource-panel > h2 {
     font-size: 16px;
+  }
+
+  .victoria-news-list .victoria-news-item {
+    padding: 26px 0 25px;
+  }
+
+  .victoria-news-list .victoria-news-item > h2 {
+    font-size: 21px;
+    line-height: 1.38;
   }
 
   .victoria-entry-page .victoria-secondary-nav {
@@ -1468,6 +1508,15 @@ body.layout-about .homepage-victoria .homepage-publications-list ol.bibliography
   .victoria-resource-copy,
   .victoria-post-meta {
     padding-left: 0;
+  }
+
+  .victoria-news-list .victoria-news-item > h2 {
+    font-size: 17px;
+  }
+
+  .victoria-news-meta {
+    margin-left: 21px;
+    font-size: 12px;
   }
 
   .victoria-entry-header {


### PR DESCRIPTION
## Summary
- render each News item as a semantic title-first article with subordinate date metadata
- preserve the approved Option A editorial spacing, square accents, restrained links, and subtle separators
- add Blog-style pagination with five entries per page at `/news/`, `/news/page/2/`, and `/news/page/3/`
- preserve all 11 existing News entries exactly once in reverse chronological order
- use server-built Jekyll pages with baseurl-aware links and accessible current/disabled/Prev/Next states

## Validation
- `npx prettier . --check`
- `JEKYLL_ENV=production bundle exec jekyll build --baseurl /previews/news-editorial-list`
- `npx purgecss -c purgecss.config.js`
- `git diff --check`
- generated route audit: 5 + 5 + 1 entries, 11/11 unique, exact chronology, title before `<time>`
- desktop/mobile branch-preview verification and screenshots

AI-assisted implementation and validation with OpenClaw.