### PR TITLE
Fix Chrome publication venue and award styles

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -1088,7 +1088,7 @@ body.layout-about .homepage-victoria .homepage-publications-list .links button.a
 
 body.layout-about .homepage-victoria .homepage-publications-list ol.bibliography > li div.award.hidden,
 .victoria-publications-page ol.bibliography > li div.award.hidden,
-.victoria-publications-page div.abstract.hidden,
+.victoria-publications-page ol.bibliography > li div.abstract.hidden,
 .victoria-publications-page div.bibtex.hidden {
   max-height: 0;
   margin: 0;
@@ -1111,7 +1111,7 @@ body.layout-about .homepage-victoria .homepage-publications-list ol.bibliography
 
 body.layout-about .homepage-victoria .homepage-publications-list ol.bibliography > li div.award.hidden.open,
 .victoria-publications-page ol.bibliography > li div.award.hidden.open,
-.victoria-publications-page div.abstract.hidden.open,
+.victoria-publications-page ol.bibliography > li div.abstract.hidden.open,
 .victoria-publications-page div.bibtex.hidden.open {
   display: block !important;
   max-height: 38rem;
@@ -1133,7 +1133,8 @@ body.layout-about .homepage-victoria .homepage-publications-list ol.bibliography
   color: var(--homepage-muted);
 }
 
-.victoria-publications-page ol.bibliography > li div.award.hidden p {
+.victoria-publications-page ol.bibliography > li div.award.hidden p,
+.victoria-publications-page ol.bibliography > li div.abstract.hidden p {
   color: var(--victoria-muted);
 }
 

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -1879,18 +1879,18 @@ body.layout-about .homepage-victoria .homepage-publications-list .publications o
 
 // Keep author expansion text deterministic across Chromium's legacy bibliography
 // hover rules: muted at rest, then darker for pointer or keyboard interaction.
-body.layout-about .homepage-victoria .homepage-publications-list .publications ol.bibliography li .author,
-body.layout-about .homepage-victoria .homepage-publications-list .publications ol.bibliography li .author *,
+body.layout-about .homepage-victoria .homepage-publications-list ol.bibliography li .author,
+body.layout-about .homepage-victoria .homepage-publications-list ol.bibliography li .author *,
 .victoria-publications-page .publications ol.bibliography li .author,
 .victoria-publications-page .publications ol.bibliography li .author * {
   color: var(--victoria-muted) !important;
   opacity: 1 !important;
 }
 
-body.layout-about .homepage-victoria .homepage-publications-list .publications ol.bibliography li .author:hover,
-body.layout-about .homepage-victoria .homepage-publications-list .publications ol.bibliography li .author:hover *,
-body.layout-about .homepage-victoria .homepage-publications-list .publications ol.bibliography li .author:focus-within,
-body.layout-about .homepage-victoria .homepage-publications-list .publications ol.bibliography li .author:focus-within *,
+body.layout-about .homepage-victoria .homepage-publications-list ol.bibliography li .author:hover,
+body.layout-about .homepage-victoria .homepage-publications-list ol.bibliography li .author:hover *,
+body.layout-about .homepage-victoria .homepage-publications-list ol.bibliography li .author:focus-within,
+body.layout-about .homepage-victoria .homepage-publications-list ol.bibliography li .author:focus-within *,
 .victoria-publications-page .publications ol.bibliography li .author:hover,
 .victoria-publications-page .publications ol.bibliography li .author:hover *,
 .victoria-publications-page .publications ol.bibliography li .author:focus-within,

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -165,6 +165,33 @@ body.layout-about .homepage-victoria .homepage-publications-list .author > span.
   cursor: pointer;
 }
 
+body.layout-about .homepage-victoria .homepage-publications-list .author,
+body.layout-about .homepage-victoria .homepage-publications-list .author a,
+body.layout-about .homepage-victoria .homepage-publications-list .author > em,
+body.layout-about .homepage-victoria .homepage-publications-list .author .author-self,
+body.layout-about .homepage-victoria .homepage-publications-list .author > span.more-authors,
+body.layout-about .homepage-victoria .homepage-publications-list .author > span.more-authors * {
+  color: var(--homepage-muted);
+  opacity: 1;
+  transition: color 0.15s ease;
+}
+
+body.layout-about .homepage-victoria .homepage-publications-list .author:hover,
+body.layout-about .homepage-victoria .homepage-publications-list .author:hover a,
+body.layout-about .homepage-victoria .homepage-publications-list .author:hover > em,
+body.layout-about .homepage-victoria .homepage-publications-list .author:hover .author-self,
+body.layout-about .homepage-victoria .homepage-publications-list .author:hover > span.more-authors,
+body.layout-about .homepage-victoria .homepage-publications-list .author:hover > span.more-authors *,
+body.layout-about .homepage-victoria .homepage-publications-list .author:focus-within,
+body.layout-about .homepage-victoria .homepage-publications-list .author:focus-within a,
+body.layout-about .homepage-victoria .homepage-publications-list .author:focus-within > em,
+body.layout-about .homepage-victoria .homepage-publications-list .author:focus-within .author-self,
+body.layout-about .homepage-victoria .homepage-publications-list .author:focus-within > span.more-authors,
+body.layout-about .homepage-victoria .homepage-publications-list .author:focus-within > span.more-authors * {
+  color: var(--homepage-ink);
+  opacity: 1;
+}
+
 body.layout-about .homepage-victoria .homepage-publications-list .author > span.more-authors.is-expanded,
 body.layout-about .homepage-victoria .homepage-publications-list .author > span.more-authors.is-expanded:hover,
 body.layout-about .homepage-victoria .homepage-publications-list .author > span.more-authors.is-expanded:focus {
@@ -928,6 +955,33 @@ body:has(.victoria-secondary-page) > .container {
 
 .victoria-publications-page .author > span.more-authors {
   cursor: pointer;
+}
+
+.victoria-publications-page .author,
+.victoria-publications-page .author a,
+.victoria-publications-page .author > em,
+.victoria-publications-page .author .author-self,
+.victoria-publications-page .author > span.more-authors,
+.victoria-publications-page .author > span.more-authors * {
+  color: var(--victoria-muted);
+  opacity: 1;
+  transition: color 0.15s ease;
+}
+
+.victoria-publications-page .author:hover,
+.victoria-publications-page .author:hover a,
+.victoria-publications-page .author:hover > em,
+.victoria-publications-page .author:hover .author-self,
+.victoria-publications-page .author:hover > span.more-authors,
+.victoria-publications-page .author:hover > span.more-authors *,
+.victoria-publications-page .author:focus-within,
+.victoria-publications-page .author:focus-within a,
+.victoria-publications-page .author:focus-within > em,
+.victoria-publications-page .author:focus-within .author-self,
+.victoria-publications-page .author:focus-within > span.more-authors,
+.victoria-publications-page .author:focus-within > span.more-authors * {
+  color: var(--victoria-ink);
+  opacity: 1;
 }
 
 .victoria-publications-page .author > span.more-authors:not(.is-expanded) {

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -184,6 +184,12 @@ body.layout-about .homepage-victoria .homepage-publications-list .periodical {
   line-height: 1.45;
 }
 
+body.layout-about .homepage-victoria .homepage-publications-list .periodical em {
+  color: inherit;
+  font-weight: inherit;
+  opacity: 1;
+}
+
 body.layout-about .homepage-victoria .homepage-publications-list .links {
   display: flex;
   flex-wrap: wrap;
@@ -950,6 +956,12 @@ body:has(.victoria-secondary-page) > .container {
   line-height: 1.45;
 }
 
+.victoria-publications-page .periodical em {
+  color: inherit;
+  font-weight: inherit;
+  opacity: 1;
+}
+
 .victoria-publications-page .periodical:empty {
   display: none;
 }
@@ -1074,8 +1086,8 @@ body.layout-about .homepage-victoria .homepage-publications-list .links button.a
   vertical-align: middle;
 }
 
-body.layout-about .homepage-victoria .homepage-publications-list div.award.hidden,
-.victoria-publications-page div.award.hidden,
+body.layout-about .homepage-victoria .homepage-publications-list ol.bibliography > li div.award.hidden,
+.victoria-publications-page ol.bibliography > li div.award.hidden,
 .victoria-publications-page div.abstract.hidden,
 .victoria-publications-page div.bibtex.hidden {
   max-height: 0;
@@ -1083,13 +1095,22 @@ body.layout-about .homepage-victoria .homepage-publications-list div.award.hidde
   overflow: hidden;
   border: 0 solid transparent;
   background: #fbfaf8;
-  color: var(--victoria-ink);
   text-align: left;
   transition: max-height 0.18s ease, margin 0.18s ease, border-width 0.18s ease;
 }
 
-body.layout-about .homepage-victoria .homepage-publications-list div.award.hidden.open,
-.victoria-publications-page div.award.hidden.open,
+body.layout-about .homepage-victoria .homepage-publications-list ol.bibliography > li div.award.hidden {
+  color: var(--homepage-muted);
+  opacity: 1;
+}
+
+.victoria-publications-page ol.bibliography > li div.award.hidden {
+  color: var(--victoria-muted);
+  opacity: 1;
+}
+
+body.layout-about .homepage-victoria .homepage-publications-list ol.bibliography > li div.award.hidden.open,
+.victoria-publications-page ol.bibliography > li div.award.hidden.open,
 .victoria-publications-page div.abstract.hidden.open,
 .victoria-publications-page div.bibtex.hidden.open {
   display: block !important;
@@ -1103,9 +1124,17 @@ body.layout-about .homepage-victoria .homepage-publications-list ol.bibliography
 .victoria-publications-page ol.bibliography > li div.abstract.hidden p {
   margin: 0;
   padding: 5px 12px;
-  color: var(--victoria-ink);
   font-size: 13.5px;
   line-height: 1.5;
+  opacity: 1;
+}
+
+body.layout-about .homepage-victoria .homepage-publications-list ol.bibliography > li div.award.hidden p {
+  color: var(--homepage-muted);
+}
+
+.victoria-publications-page ol.bibliography > li div.award.hidden p {
+  color: var(--victoria-muted);
 }
 
 .victoria-publications-page div.bibtex.hidden figure.highlight {

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -1880,17 +1880,25 @@ body.layout-about .homepage-victoria .homepage-publications-list .publications o
 // Keep author expansion text deterministic across Chromium's legacy bibliography
 // hover rules: muted at rest, then darker for pointer or keyboard interaction.
 body.layout-about .homepage-victoria .homepage-publications-list ol.bibliography li .author,
-body.layout-about .homepage-victoria .homepage-publications-list ol.bibliography li .author *,
-.victoria-publications-page .publications ol.bibliography li .author,
-.victoria-publications-page .publications ol.bibliography li .author * {
-  color: var(--victoria-muted) !important;
+body.layout-about .homepage-victoria .homepage-publications-list ol.bibliography li .author * {
+  color: var(--homepage-muted) !important;
   opacity: 1 !important;
 }
 
 body.layout-about .homepage-victoria .homepage-publications-list ol.bibliography li .author:hover,
 body.layout-about .homepage-victoria .homepage-publications-list ol.bibliography li .author:hover *,
 body.layout-about .homepage-victoria .homepage-publications-list ol.bibliography li .author:focus-within,
-body.layout-about .homepage-victoria .homepage-publications-list ol.bibliography li .author:focus-within *,
+body.layout-about .homepage-victoria .homepage-publications-list ol.bibliography li .author:focus-within * {
+  color: var(--homepage-ink) !important;
+  opacity: 1 !important;
+}
+
+.victoria-publications-page .publications ol.bibliography li .author,
+.victoria-publications-page .publications ol.bibliography li .author * {
+  color: var(--victoria-muted) !important;
+  opacity: 1 !important;
+}
+
 .victoria-publications-page .publications ol.bibliography li .author:hover,
 .victoria-publications-page .publications ol.bibliography li .author:hover *,
 .victoria-publications-page .publications ol.bibliography li .author:focus-within,

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -1876,3 +1876,25 @@ body.layout-about .homepage-victoria .homepage-publications-list .publications o
   -webkit-box-orient: vertical;
   -webkit-line-clamp: 4;
 }
+
+// Keep author expansion text deterministic across Chromium's legacy bibliography
+// hover rules: muted at rest, then darker for pointer or keyboard interaction.
+body.layout-about .homepage-victoria .homepage-publications-list .publications ol.bibliography li .author,
+body.layout-about .homepage-victoria .homepage-publications-list .publications ol.bibliography li .author *,
+.victoria-publications-page .publications ol.bibliography li .author,
+.victoria-publications-page .publications ol.bibliography li .author * {
+  color: var(--victoria-muted) !important;
+  opacity: 1 !important;
+}
+
+body.layout-about .homepage-victoria .homepage-publications-list .publications ol.bibliography li .author:hover,
+body.layout-about .homepage-victoria .homepage-publications-list .publications ol.bibliography li .author:hover *,
+body.layout-about .homepage-victoria .homepage-publications-list .publications ol.bibliography li .author:focus-within,
+body.layout-about .homepage-victoria .homepage-publications-list .publications ol.bibliography li .author:focus-within *,
+.victoria-publications-page .publications ol.bibliography li .author:hover,
+.victoria-publications-page .publications ol.bibliography li .author:hover *,
+.victoria-publications-page .publications ol.bibliography li .author:focus-within,
+.victoria-publications-page .publications ol.bibliography li .author:focus-within * {
+  color: var(--victoria-ink) !important;
+  opacity: 1 !important;
+}


### PR DESCRIPTION
## Summary
- keep journal/booktitle venue text italic but inherit the readable secondary publication color in Chrome
- remove the legacy dashed award-container border in collapsed and expanded states while preserving the approved solid box
- give expanded award details an explicit secondary text color and full opacity on both homepage and Publications
- retain the existing mouse-focus suppression and button-scoped `:focus-visible` ring

## Root causes
- the global `em` color (`black`) overrode `.periodical`'s secondary color in Chromium, so the nested venue segment did not consistently share its record metadata styling
- `_sass/_base.scss` emits `ol.bibliography div.award.hidden{border:dashed...}` with greater specificity than the intended custom award-box selector, producing the full-width dashed line
- award detail color was not independently scoped per homepage/full-publications surface

## Validation
- `npx prettier --check assets/css/main.scss`
- `bundle exec jekyll build`
- `npx purgecss --config purgecss.config.js`
- `git diff --check`
- local Chromium desktop/mobile on `/` and `/publications/`: collapsed/expanded Award, mouse/programmatic focus, keyboard `:focus-visible`

## Browser results
- venue: `#565656`, opacity `1` (7.34:1 on white)
- award details: `#565656`, opacity `1` (7.04:1 on `#fbfaf8`)
- collapsed award container: `border: 0 solid transparent`
- expanded award container: `1px solid #e6e0d8` (no dashed line)
- mouse/programmatic focus: no outline; keyboard focus: 2px button-local ring

AI-assisted: CSS diagnosis, implementation, and Chromium verification were performed with OpenAI Codex.
