### PR TITLE
Fix faint homepage text and icons in Chromium

### DIFF
--- a/_layouts/about.liquid
+++ b/_layouts/about.liquid
@@ -38,7 +38,7 @@ layout: default
           <div class="affiliation">Microsoft Research Asia</div>
           <div class="email">
             <i class="fa fa-envelope" aria-hidden="true"></i>
-            <span>yang DOT fan AT acm DOT org</span>
+            <a class="contact-email-link" href="mailto:yang.fan@acm.org">yang DOT fan AT acm DOT org</a>
           </div>
           <div class="social-networks" aria-label="Profile links">
             {% if site.work_url %}

--- a/_pages/about.md
+++ b/_pages/about.md
@@ -17,4 +17,4 @@ My research passion lies in computer systems. My recent focus is on exploring th
 
 As a researcher, I also engage in public academic services, including serving on the program committees of ASPLOS ([2022](https://www.asplos-conference.org/asplos2022/index.html%3Fp=44.html)), EuroSys ([2023](https://2023.eurosys.org/pc.html), [2025](https://2025.eurosys.org/pc.html), [2026](https://2026.eurosys.org/pc.html)), OSDI ([2026](https://www.usenix.org/conference/osdi26/call-for-papers)), SOSP ([2026](https://sigops.org/s/conferences/sosp/2026/organizers.html)).
 
-##### **We are recruiting interns the whole year, details [here](https://fanyangcs.github.io/news/intern_opportunities/).**
+<h5 class="recruitment-notice"><strong>We are recruiting interns the whole year, details <a class="recruitment-link" href="https://fanyangcs.github.io/news/intern_opportunities/">here</a>.</strong></h5>

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -26,6 +26,60 @@ $max-content-width: {{ site.max_width }};
   "tabler-icons/tabler-icons-outline.scss"
 ;
 
+// Homepage contrast: the base typography rules below assign --global-text-color
+// directly to spans, emphasis, and strong text. Reassert the homepage palette on
+// these exact components so they do not depend on inherited-color behavior.
+body.layout-about .homepage-victoria {
+  .contacts .email,
+  .contacts .email i,
+  .contacts .email .contact-email-link,
+  .contacts .email .contact-email-link:visited {
+    color: var(--homepage-muted);
+    opacity: 1;
+  }
+
+  .contacts .email .contact-email-link:hover,
+  .contacts .email .contact-email-link:focus {
+    color: var(--homepage-accent);
+    text-decoration: underline;
+  }
+
+  .contacts .social-networks a,
+  .contacts .social-networks a:visited,
+  .contacts .social-networks .openreview-badge {
+    color: var(--homepage-ink);
+    opacity: 1;
+  }
+
+  .contacts .social-networks .openreview-badge {
+    border-width: 2px;
+  }
+
+  .about-me-section em {
+    color: var(--homepage-ink);
+    opacity: 1;
+    font-style: italic;
+  }
+
+  .about-me-section .recruitment-notice,
+  .about-me-section .recruitment-notice strong {
+    color: var(--homepage-ink);
+    opacity: 1;
+  }
+
+  .about-me-section .recruitment-link,
+  .about-me-section .recruitment-link:visited {
+    color: var(--homepage-accent);
+    opacity: 1;
+    text-decoration: underline;
+  }
+
+  .about-me-section .recruitment-link:hover,
+  .about-me-section .recruitment-link:focus {
+    color: #2f536f;
+  }
+}
+
 // AI-assisted homepage preview override: keep section headings prominent and unruled.
 // The desktop masthead contact spacing (10px gap) lives in _sass/_layout.scss.
 body.layout-about .section h3 {


### PR DESCRIPTION
## Summary
- make homepage contact text and its new `mailto:` interaction use deterministic readable colors
- normalize OpenReview badge color/opacity/weight with adjacent social icons
- scope readable italic and recruitment notice/link styles to the homepage About section

## Root cause
Global `_sass/_base.scss` typography selectors assign `--global-text-color` directly to `span`, `em`, and `strong`, so those descendants do not inherit the Victoria homepage palette. The custom OpenReview control also combined parent opacity `0.86` with a thinner 1.5px border. This change reasserts explicit homepage values after imports without touching publication venue styling handled separately in PR #9.

## Validation
- Prettier check
- `bundle exec jekyll build`
- PurgeCSS
- `git diff --check`
- Chromium desktop/mobile light + `prefers-color-scheme: dark`
- smoke checks: homepage, News pagination page, Publications, 404

AI-assisted change: implementation, browser inspection, and validation were performed with AI assistance.
