### PR TITLE
Improve Chrome contrast on project detail pages

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -1783,6 +1783,21 @@ body.layout-about .homepage-victoria .homepage-publications-list .publications o
   line-height: 1.55;
 }
 
+// Keep project-detail metadata and emphasis deterministic in Chromium. The
+// global element rules assign their own color to spans and em elements, so
+// relying on inherited project colors makes these small styles inconsistent.
+.victoria-project-entry-page .victoria-entry-meta span {
+  color: #3f3f3f !important;
+  font-weight: 700;
+  opacity: 1;
+}
+
+.victoria-project-entry-content em {
+  color: var(--victoria-ink) !important;
+  font-style: italic;
+  opacity: 1;
+}
+
 .victoria-project-entry-content img,
 .victoria-project-entry-page .card-img,
 .victoria-project-entry-page .card-img-top,
@@ -1800,9 +1815,8 @@ body.layout-about .homepage-victoria .homepage-publications-list .publications o
 
 .victoria-project-section-heading {
   margin: 0 0 15px;
-  padding: 17px 0 0;
+  padding: 0;
   border: 0;
-  border-top: 1px solid var(--victoria-rule);
   color: var(--victoria-ink) !important;
   font-family: inherit;
   font-size: 20px;


### PR DESCRIPTION
## Summary
- give project metadata labels an explicit readable secondary color and full opacity
- keep project-body emphasis italic while assigning the normal readable body foreground
- remove only the dedicated top rule and padding from the shared References heading

The selectors are scoped to project detail pages, so publication venues and other site pages are unchanged.

## Validation
- `npx prettier . --check`
- `bundle exec jekyll build`
- `npx purgecss -c purgecss.config.js`
- `git diff --check`
- inspected all 7 generated project detail pages
- Chromium 148 desktop/mobile screenshots and computed-style assertions on Agentic AI, AI compiler, and Graph
- metadata `#3f3f3f` on white: 10.53:1; emphasis `#080808`: 20.03:1; opacity 1

AI-assisted: implemented and validated with OpenClaw.
