### PR TITLE
Fix iOS homepage contrast caching

### DIFF
--- a/.github/workflows/branch-preview.yml
+++ b/.github/workflows/branch-preview.yml
@@ -12,6 +12,7 @@ on:
       - "**.html"
       - "**.js"
       - "**.liquid"
+      - "**.rb"
       - "**/*.md"
       - "**.yml"
       - "Gemfile"
@@ -62,6 +63,7 @@ jobs:
       - name: Install and Build 🔧
         run: |
           pip3 install --upgrade jupyter
+          ruby test/cache_bust_test.rb
           export JEKYLL_ENV=production
           bundle exec jekyll build
       - name: Purge unused CSS 🧹

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,6 +11,7 @@ on:
       - "**.html"
       - "**.js"
       - "**.liquid"
+      - "**.rb"
       - "**/*.md"
       - "**.yml"
       - "Gemfile"
@@ -38,6 +39,7 @@ on:
       - "**.html"
       - "**.js"
       - "**.liquid"
+      - "**.rb"
       - "**/*.md"
       - "**.yml"
       - "Gemfile"
@@ -85,6 +87,7 @@ jobs:
       - name: Install and Build 🔧
         run: |
           pip3 install --upgrade jupyter
+          ruby test/cache_bust_test.rb
           export JEKYLL_ENV=production
           bundle exec jekyll build
       - name: Purge unused CSS 🧹

--- a/_plugins/cache-bust.rb
+++ b/_plugins/cache-bust.rb
@@ -20,8 +20,8 @@ module Jekyll
       private
 
       def directory_files_content
-        target_path = File.join(directory, '**', '*')
-        Dir[target_path].map{|f| File.read(f) unless File.directory?(f) }.join
+        source_paths = Array(directory).flat_map { |path| Dir[File.join(path, '**', '*')] }
+        source_paths.sort.filter_map { |path| File.read(path) unless File.directory?(path) }.join
       end
 
       def file_content
@@ -43,7 +43,10 @@ module Jekyll
     end
 
     def bust_css_cache(file_name)
-      CacheDigester.new(file_name: file_name, directory: 'assets/_sass').digest!
+      # main.css is compiled from both the entrypoint and Sass partials. The old
+      # assets/_sass path does not exist, so every build emitted MD5(empty) and
+      # browsers could keep stale CSS under an unchanged URL.
+      CacheDigester.new(file_name: file_name, directory: ['assets/css/main.scss', '_sass']).digest!
     end
   end
 end

--- a/_plugins/cache-bust.rb
+++ b/_plugins/cache-bust.rb
@@ -4,13 +4,13 @@ module Jekyll
   module CacheBust
     class CacheDigester
       require 'digest/md5'
-      require 'pathname'
 
-      attr_accessor :file_name, :directory
+      attr_accessor :file_name, :directory, :additional_content
 
-      def initialize(file_name:, directory: nil)
+      def initialize(file_name:, directory: nil, additional_content: nil)
         self.file_name = file_name
         self.directory = directory
+        self.additional_content = additional_content
       end
 
       def digest!
@@ -20,33 +20,46 @@ module Jekyll
       private
 
       def directory_files_content
-        source_paths = Array(directory).flat_map { |path| Dir[File.join(path, '**', '*')] }
-        source_paths.sort.filter_map { |path| File.read(path) unless File.directory?(path) }.join
+        source_paths = Array(directory).flat_map do |path|
+          File.file?(path) ? [path] : Dir.glob(File.join(path, '**', '*')).select { |entry| File.file?(entry) }
+        end
+        source_paths = source_paths.uniq.sort
+        raise ArgumentError, 'cache digest has no source files' if source_paths.empty?
+
+        source_paths.map { |path| framed(path, File.binread(path)) }.join
+      end
+
+      def framed(path, content)
+        "#{path.bytesize}:#{path}#{content.bytesize}:#{content}"
       end
 
       def file_content
-        local_file_name = file_name.slice((file_name.index('assets/')..-1))
-        File.read(local_file_name)
+        assets_index = file_name.index('assets/')
+        raise ArgumentError, "asset URL does not contain assets/: #{file_name}" unless assets_index
+
+        File.binread(file_name.slice(assets_index..-1))
       end
 
       def file_contents
-        is_directory? ? file_content : directory_files_content
-      end
-
-      def is_directory?
-        directory.nil?
+        content = directory.nil? ? file_content : directory_files_content
+        additional_content.nil? ? content : content + framed('additional_content', additional_content.to_s)
       end
     end
 
     def bust_file_cache(file_name)
-      CacheDigester.new(file_name: file_name, directory: nil).digest!
+      CacheDigester.new(file_name: file_name).digest!
     end
 
     def bust_css_cache(file_name)
-      # main.css is compiled from both the entrypoint and Sass partials. The old
-      # assets/_sass path does not exist, so every build emitted MD5(empty) and
-      # browsers could keep stale CSS under an unchanged URL.
-      CacheDigester.new(file_name: file_name, directory: ['assets/css/main.scss', '_sass']).digest!
+      # main.css is compiled from its Liquid-rendered entrypoint and Sass partials.
+      # The old assets/_sass path does not exist, so it emitted MD5(empty).
+      config = @context.registers[:site].config
+      css_config = [config['max_width'], config['sass']]
+      CacheDigester.new(
+        file_name: file_name,
+        directory: ['assets/css/main.scss', '_sass'],
+        additional_content: Marshal.dump(css_config)
+      ).digest!
     end
   end
 end

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -35,7 +35,6 @@ body.layout-about .homepage-victoria {
   .contacts .email .contact-email-link,
   .contacts .email .contact-email-link:visited {
     color: var(--homepage-muted);
-    -webkit-text-fill-color: currentColor;
     opacity: 1;
   }
 
@@ -49,17 +48,15 @@ body.layout-about .homepage-victoria {
   .contacts .social-networks a:visited,
   .contacts .social-networks .openreview-badge {
     color: var(--homepage-ink);
-    -webkit-text-fill-color: currentColor;
     opacity: 1;
   }
 
   .contacts .social-networks .openreview-badge {
-    border: 2px solid currentColor;
+    border-width: 2px;
   }
 
   .about-me-section em {
     color: var(--homepage-ink);
-    -webkit-text-fill-color: currentColor;
     opacity: 1;
     font-style: italic;
   }
@@ -67,14 +64,12 @@ body.layout-about .homepage-victoria {
   .about-me-section .recruitment-notice,
   .about-me-section .recruitment-notice strong {
     color: var(--homepage-ink);
-    -webkit-text-fill-color: currentColor;
     opacity: 1;
   }
 
   .about-me-section .recruitment-link,
   .about-me-section .recruitment-link:visited {
     color: var(--homepage-accent);
-    -webkit-text-fill-color: currentColor;
     opacity: 1;
     text-decoration: underline;
   }

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -35,6 +35,7 @@ body.layout-about .homepage-victoria {
   .contacts .email .contact-email-link,
   .contacts .email .contact-email-link:visited {
     color: var(--homepage-muted);
+    -webkit-text-fill-color: currentColor;
     opacity: 1;
   }
 
@@ -48,15 +49,17 @@ body.layout-about .homepage-victoria {
   .contacts .social-networks a:visited,
   .contacts .social-networks .openreview-badge {
     color: var(--homepage-ink);
+    -webkit-text-fill-color: currentColor;
     opacity: 1;
   }
 
   .contacts .social-networks .openreview-badge {
-    border-width: 2px;
+    border: 2px solid currentColor;
   }
 
   .about-me-section em {
     color: var(--homepage-ink);
+    -webkit-text-fill-color: currentColor;
     opacity: 1;
     font-style: italic;
   }
@@ -64,12 +67,14 @@ body.layout-about .homepage-victoria {
   .about-me-section .recruitment-notice,
   .about-me-section .recruitment-notice strong {
     color: var(--homepage-ink);
+    -webkit-text-fill-color: currentColor;
     opacity: 1;
   }
 
   .about-me-section .recruitment-link,
   .about-me-section .recruitment-link:visited {
     color: var(--homepage-accent);
+    -webkit-text-fill-color: currentColor;
     opacity: 1;
     text-decoration: underline;
   }

--- a/test/cache_bust_test.rb
+++ b/test/cache_bust_test.rb
@@ -1,0 +1,79 @@
+# AI-assisted regression coverage for the CSS cache key.
+require 'fileutils'
+require 'minitest/autorun'
+require 'tmpdir'
+
+module Liquid
+  class Template
+    def self.register_filter(_filter); end
+  end
+end
+
+require_relative '../_plugins/cache-bust'
+
+class CacheBustTest < Minitest::Test
+  CacheDigester = Jekyll::CacheBust::CacheDigester
+
+  def setup
+    @tmpdir = Dir.mktmpdir('cache-bust-test')
+    @entrypoint = File.join(@tmpdir, 'main.scss')
+    @partials = File.join(@tmpdir, '_sass')
+    FileUtils.mkdir_p(@partials)
+    File.write(@entrypoint, 'body { color: black; }')
+    File.write(File.join(@partials, '_base.scss'), 'a { color: blue; }')
+  end
+
+  def teardown
+    FileUtils.remove_entry(@tmpdir)
+  end
+
+  def test_digest_is_nonempty_stable_and_independent_of_input_order
+    forward = digest([@entrypoint, @partials])
+    reverse = digest([@partials, @entrypoint])
+
+    refute_equal Digest::MD5.hexdigest(''), digest_value(forward)
+    assert_equal forward, reverse
+  end
+
+  def test_a_single_directory_path_remains_supported
+    assert_equal digest(@partials), digest([@partials])
+  end
+
+  def test_digest_changes_when_entrypoint_changes
+    original = digest
+    File.write(@entrypoint, 'body { color: white; }')
+
+    refute_equal original, digest
+  end
+
+  def test_digest_changes_when_partial_changes
+    original = digest
+    File.write(File.join(@partials, '_base.scss'), 'a { color: red; }')
+
+    refute_equal original, digest
+  end
+
+  def test_digest_changes_when_liquid_config_input_changes
+    refute_equal digest(nil, '930px'), digest(nil, '960px')
+  end
+
+  def test_missing_sources_fail_instead_of_hashing_empty_content
+    error = assert_raises(ArgumentError) { digest([File.join(@tmpdir, 'missing')]) }
+
+    assert_equal 'cache digest has no source files', error.message
+  end
+
+  private
+
+  def digest(paths = nil, additional_content = nil)
+    CacheDigester.new(
+      file_name: '/assets/css/main.css',
+      directory: paths || [@entrypoint, @partials],
+      additional_content: additional_content
+    ).digest!
+  end
+
+  def digest_value(url)
+    url.split('?', 2).last
+  end
+end


### PR DESCRIPTION
## Summary
- repair the `main.css` cache key so it hashes the real Sass entrypoint and partials instead of the nonexistent `assets/_sass` directory
- include the Liquid/config inputs that affect the compiled CSS (`max_width` and Sass config)
- sort, deduplicate, frame, and binary-read source inputs; fail closed instead of ever emitting MD5(empty)
- add focused Minitest coverage and run it in deploy/preview CI
- remove the proposed WebKit-only CSS declarations after audit: current `master` already renders the intended colors in Chromium and iPhone WebKit, so this PR is now cache-busting-only

## Root cause
PR #10 is already in current `master`, and its homepage selectors compute the intended colors. However, deployed HTML referenced `main.css?d41d8cd98f00b204e9800998ecf8427e`—MD5(empty)—because `bust_css_cache` scanned `assets/_sass`, which does not exist. The URL therefore stayed unchanged across CSS deployments, allowing a browser/CDN cache to retain an older stylesheet.

## Audit / verification
- latest `origin/master` (`8f47c173`, including PR #14) was merged into this branch cleanly with no conflicts; backup refs were created before integration
- `ruby test/cache_bust_test.rb`: 6 runs, 8 assertions; proves non-empty/stable digest, string/array and path-order compatibility, entrypoint/partial/config sensitivity, and missing-source failure
- `ruby -c _plugins/cache-bust.rb`
- `npx prettier . --check`
- two unchanged production builds: identical URL `main.css?e0f192d54fc9cdee8a7ea76b530de95a` and identical CSS SHA-256 `dce61c7245a8964647fc340c894f449c4698a3910591fe62d485d4bf8b7de945`
- production Jekyll build and preview-baseurl Jekyll build
- `npx purgecss -c purgecss.config.js`
- `git diff --check`
- preview at 390×844 in Chromium and Playwright WebKit: email/social/emphasis/recruitment text visible with expected computed colors and opacity 1; CSS fetched successfully and retained the non-empty query on reload

## Recommendation
**Merge after the exact-head Prettier and branch-preview checks are green.** The root-cause fix is valid and now narrowly scoped to deterministic cache invalidation; no WebKit paint override is needed.

AI-assisted change. Please review; this PR has intentionally **not** been merged.
