### PR TITLE
Fix iOS WebKit blog article contrast

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -1526,6 +1526,25 @@ body.layout-about .homepage-victoria .homepage-publications-list ol.bibliography
   color: var(--victoria-ink);
 }
 
+// Blog entries intentionally keep a white editorial surface in both OS color
+// schemes. The global typography rules assign dark-theme foregrounds directly
+// to emphasis elements, so reassert this surface's palette for WebKit and other
+// engines instead of relying on inheritance from the article container.
+.victoria-blog-entry-page .victoria-entry-title,
+.victoria-blog-entry-page .post-title {
+  color: var(--victoria-accent) !important;
+  -webkit-text-fill-color: currentColor;
+  opacity: 1;
+}
+
+.victoria-blog-entry-page .victoria-entry-content em,
+.victoria-blog-entry-page .victoria-entry-content i,
+.victoria-blog-entry-page .victoria-entry-content strong {
+  color: var(--victoria-ink);
+  -webkit-text-fill-color: currentColor;
+  opacity: 1;
+}
+
 .victoria-entry-page > h2,
 .victoria-entry-page .related-posts h2 {
   margin-top: 34px;


### PR DESCRIPTION
## Summary
- keep blog article titles on the intended dark-brown editorial color in iOS WebKit
- make blog article `em`, `i`, and `strong` text deterministic on the intentionally white surface across light/dark OS preferences
- preserve italic semantics and scope the change to Blog entries only

## Root cause
Global typography styles assign `--global-text-color` directly to emphasis elements. Under system dark preference that becomes `#e8e8e8`, while Victoria article pages intentionally stay white and use their own local palette. As a result, emphasized transcript paragraphs became near-white on white.

## Verification
- Prettier check passed
- `git diff --check` passed
- Jekyll generated the target CSS; local minification exceeded the 240s guard after generation
- PurgeCSS passed and retained both new selectors
- Playwright WebKit: iPhone 390×844 and 375×812, light and dark preferences
- Playwright Chromium: desktop and mobile/dark
- representative English Blog post and Blog listing checked

Computed results on white:
- title `#6b4f29`: 7.57:1
- emphasized/strong article text `#080808`: 20.03:1

AI-assisted change; reviewed and tested locally.