### PR TITLE
Restore mobile article navigation and align Blog list typography

### DIFF
--- a/_includes/victoria_nav.liquid
+++ b/_includes/victoria_nav.liquid
@@ -52,7 +52,7 @@
 
 <details class="homepage-mobile-menu victoria-secondary-mobile-menu">
   {%- comment -%} Mobile hamburger menu mirrors the homepage Victoria-style menu. {%- endcomment -%}
-  <summary aria-label="Open site navigation">
+  <summary aria-label="Open site navigation" aria-expanded="false">
     <span class="homepage-menu-icon" aria-hidden="true"><span></span><span></span><span></span></span>
   </summary>
   <nav class="homepage-mobile-menu-panel" aria-label="Site navigation">
@@ -63,3 +63,25 @@
     <a href="{{ projects_url }}">Projects</a>
   </nav>
 </details>
+<script>
+  (() => {
+    const menu = document.currentScript.previousElementSibling;
+    const toggle = menu.querySelector('summary');
+    const setExpanded = () => toggle.setAttribute('aria-expanded', menu.open ? 'true' : 'false');
+    const closeMenu = () => {
+      menu.removeAttribute('open');
+      setExpanded();
+    };
+
+    menu.addEventListener('toggle', setExpanded);
+    document.addEventListener('click', (event) => {
+      if (menu.open && !menu.contains(event.target)) closeMenu();
+    });
+    document.addEventListener('keydown', (event) => {
+      if (event.key === 'Escape' && menu.open) {
+        closeMenu();
+        toggle.focus();
+      }
+    });
+  })();
+</script>

--- a/_layouts/post.liquid
+++ b/_layouts/post.liquid
@@ -25,25 +25,7 @@ layout: default
 {% endif %}
 
 <div class="post victoria-secondary-page victoria-entry-page victoria-{{ entry_section }}-entry-page">
-  <nav class="victoria-secondary-nav" aria-label="Site navigation">
-    <a href="{{ '/' | relative_url }}">About</a>
-    <a
-      href="{{ '/blog/' | relative_url }}"
-      {% if entry_section == 'blog' %}
-        aria-current="page"
-      {% endif %}
-      >Blog</a
-    >
-    <a
-      href="{{ '/news/' | relative_url }}"
-      {% if entry_section == 'news' %}
-        aria-current="page"
-      {% endif %}
-      >News</a
-    >
-    <a href="{{ '/publications/' | relative_url }}">Publications</a>
-    <a href="{{ '/projects/' | relative_url }}">Projects</a>
-  </nav>
+  {% include victoria_nav.liquid current=entry_section %}
 
   <header class="post-header victoria-entry-header">
     <p class="victoria-entry-kicker">{{ entry_label }}</p>

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -804,15 +804,18 @@ body:has(.victoria-secondary-page) > .container {
   margin: 0 0 6px;
 }
 
-.victoria-news-list .victoria-news-item {
+.victoria-news-list .victoria-news-item,
+.victoria-blog-list .victoria-blog-item {
   padding: 26px 0 24px;
 }
 
-.victoria-news-list .victoria-news-item:first-child {
+.victoria-news-list .victoria-news-item:first-child,
+.victoria-blog-list .victoria-blog-item:first-child {
   padding-top: 9px;
 }
 
-.victoria-news-list .victoria-news-item > h2 {
+.victoria-news-list .victoria-news-item > h2,
+.victoria-blog-list .victoria-blog-item > h2 {
   gap: 13px;
   margin-bottom: 10px;
   font-size: 22px;
@@ -820,17 +823,21 @@ body:has(.victoria-secondary-page) > .container {
   letter-spacing: -0.006em;
 }
 
-.victoria-news-list .victoria-news-item > h2::before {
+.victoria-news-list .victoria-news-item > h2::before,
+.victoria-blog-list .victoria-blog-item > h2::before {
   width: 8px;
   height: 8px;
 }
 
-.victoria-news-list .victoria-news-item > h2 a {
+.victoria-news-list .victoria-news-item > h2 a,
+.victoria-blog-list .victoria-blog-item > h2 a {
   color: var(--victoria-accent);
 }
 
-.victoria-news-meta {
+.victoria-news-meta,
+.victoria-post-meta {
   margin: 0 0 0 21px;
+  padding-left: 0;
   color: var(--victoria-muted) !important;
   font-size: 13px;
   font-weight: 600;
@@ -841,17 +848,6 @@ body:has(.victoria-secondary-page) > .container {
 
 .victoria-news-meta time {
   color: inherit;
-}
-
-.victoria-post-meta {
-  margin: 5px 0 0;
-  padding-left: 17px;
-  color: var(--victoria-muted) !important;
-  font-size: 13px;
-  font-weight: 600;
-  line-height: 1.35;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
 }
 
 .victoria-blog-page .victoria-pagination,
@@ -1617,11 +1613,13 @@ body.layout-about .homepage-victoria .homepage-publications-list ol.bibliography
     font-size: 16px;
   }
 
-  .victoria-news-list .victoria-news-item {
+  .victoria-news-list .victoria-news-item,
+  .victoria-blog-list .victoria-blog-item {
     padding: 26px 0 25px;
   }
 
-  .victoria-news-list .victoria-news-item > h2 {
+  .victoria-news-list .victoria-news-item > h2,
+  .victoria-blog-list .victoria-blog-item > h2 {
     font-size: 21px;
     line-height: 1.38;
   }
@@ -1652,16 +1650,17 @@ body.layout-about .homepage-victoria .homepage-publications-list ol.bibliography
     font-size: 23px;
   }
 
-  .victoria-resource-copy,
-  .victoria-post-meta {
+  .victoria-resource-copy {
     padding-left: 0;
   }
 
-  .victoria-news-list .victoria-news-item > h2 {
+  .victoria-news-list .victoria-news-item > h2,
+  .victoria-blog-list .victoria-blog-item > h2 {
     font-size: 17px;
   }
 
-  .victoria-news-meta {
+  .victoria-news-meta,
+  .victoria-post-meta {
     margin-left: 21px;
     font-size: 12px;
   }


### PR DESCRIPTION
## Summary
- reuse the shared Victoria navigation include on Blog and News article layouts so the existing mobile hamburger is present
- synchronize `aria-expanded` and support Escape/outside-click close behavior
- align Blog list title/date hierarchy, color, and spacing with the News list while preserving excerpts and pagination

## Root cause
`_layouts/post.liquid` duplicated only the desktop `.victoria-secondary-nav` markup instead of including `_includes/victoria_nav.liquid`, which also owns the mobile `<details>` menu. Blog list items also continued to use the smaller generic resource-panel typography while News had dedicated larger/accent selectors.

## Validation
- `npx prettier . --check`
- `bundle exec jekyll build`
- `purgecss -c purgecss.config.js`
- Playwright Chromium + WebKit at 390×844, 375×812, and 1280×900
- Blog, Blog article (`A podcast on AI reasoning`), News, News article, Publications, Projects, 404, and homepage smoke tests
- verified tap/click open, `aria-expanded`, Escape close/focus return, outside-click close, 5 baseurl-safe links, and zero horizontal overflow

## AI disclosure
This change was implemented and verified with AI assistance (OpenAI Codex).