### PR TITLE
Fix iOS WebKit rendering of Blog blockquotes

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -1506,6 +1506,21 @@ body.layout-about .homepage-victoria .homepage-publications-list ol.bibliography
   color: var(--victoria-muted);
 }
 
+// The base blockquote style uses the global theme background, but Blog entries
+// intentionally stay on a white editorial surface. Keep quotations readable
+// when WebKit selects the dark global palette from the OS preference.
+body.layout-post .post article.victoria-entry-content blockquote {
+  background: #fbfaf8;
+  color: var(--victoria-ink);
+  opacity: 1;
+}
+
+body.layout-post .post article.victoria-entry-content blockquote p {
+  color: var(--victoria-ink);
+  -webkit-text-fill-color: currentColor;
+  opacity: 1;
+}
+
 .victoria-entry-content pre,
 .victoria-entry-content code {
   border-radius: 0;


### PR DESCRIPTION
## Summary
- keep Blog article blockquotes on the white Victoria editorial surface in both OS color schemes
- explicitly stabilize quote paragraph foreground and WebKit text fill
- scope the fix to `body.layout-post .post article.victoria-entry-content` so inline emphasis, code, links, and blockquotes elsewhere are unchanged

## Root cause
The affected Markdown is a plain blockquote (`>`), generated as `<blockquote><p>…</p></blockquote>`, not `<mark>`, code, or inline emphasis. The global blockquote rule uses `background: var(--global-bg-color)`. Under dark OS preference, the theme script selects the dark global palette (`#1c1c1d`) even though Victoria Blog pages intentionally remain white; WebKit then paints the quote as dark wrapped rectangles. This override pins Blog quotes to a subtle near-white highlight and readable ink.

## Verification
- `npx prettier . --check`
- `bundle exec jekyll build`
- `npx purgecss -c purgecss.config.js`
- generated HTML inspected for exact sentence/tag
- Playwright WebKit at 390×844 and 375×812, light/dark OS preferences
- Playwright Chromium mobile and desktop, light/dark OS preferences

AI-assisted implementation and browser verification.