### PR TITLE
Fix theme listener when toggle controls are absent

### DIFF
--- a/assets/js/theme.js
+++ b/assets/js/theme.js
@@ -236,17 +236,20 @@ let initTheme = () => {
 
   setThemeSetting(themeSetting);
 
-  // Add event listener to the theme toggle button.
+  // Add event listener to the theme toggle button when the page includes it.
   document.addEventListener("DOMContentLoaded", function () {
-    const mode_toggle = document.getElementById("light-toggle");
+    const modeToggle = document.getElementById("light-toggle");
 
-    mode_toggle.addEventListener("click", function () {
-      toggleThemeSetting();
-    });
+    if (modeToggle) {
+      modeToggle.addEventListener("click", function () {
+        toggleThemeSetting();
+      });
+    }
   });
 
-  // Add event listener to the system theme preference change.
-  window.matchMedia("(prefers-color-scheme: dark)").addEventListener("change", ({ matches }) => {
-    applyTheme();
-  });
+  // Add event listener to the system theme preference change when supported.
+  const systemThemePreference = window.matchMedia("(prefers-color-scheme: dark)");
+  if (systemThemePreference.addEventListener) {
+    systemThemePreference.addEventListener("change", applyTheme);
+  }
 };

--- a/test/theme_test.js
+++ b/test/theme_test.js
@@ -1,0 +1,110 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const test = require("node:test");
+const vm = require("node:vm");
+
+const themeScript = fs.readFileSync("assets/js/theme.js", "utf8");
+
+function loadTheme({ hasToggle = false, prefersDark = false } = {}) {
+  const attributes = new Map();
+  const storage = new Map();
+  const listeners = {};
+  const mediaListeners = {};
+  const highlights = {
+    highlight_theme_dark: {},
+    highlight_theme_light: {},
+  };
+  const toggle = hasToggle
+    ? {
+        addEventListener(type, listener) {
+          listeners[type] = listener;
+        },
+      }
+    : null;
+
+  const document = {
+    documentElement: {
+      classList: { add() {}, remove() {} },
+      setAttribute(name, value) {
+        attributes.set(name, value);
+      },
+    },
+    addEventListener(type, listener) {
+      listeners[type] = listener;
+    },
+    getElementById(id) {
+      return id === "light-toggle" ? toggle : highlights[id];
+    },
+    getElementsByTagName() {
+      return [];
+    },
+    getElementsByClassName() {
+      return [];
+    },
+    querySelector() {
+      return null;
+    },
+  };
+  const localStorage = {
+    getItem(key) {
+      return storage.get(key) ?? null;
+    },
+    setItem(key, value) {
+      storage.set(key, value);
+    },
+  };
+  const mediaQuery = {
+    get matches() {
+      return prefersDark;
+    },
+    addEventListener(type, listener) {
+      mediaListeners[type] = listener;
+    },
+  };
+  const context = {
+    document,
+    localStorage,
+    window: {
+      matchMedia() {
+        return mediaQuery;
+      },
+      setTimeout() {},
+    },
+  };
+
+  vm.runInNewContext(`${themeScript}\ninitTheme();`, context);
+  return { attributes, listeners, mediaListeners, storage };
+}
+
+test("theme initialization is safe without a toggle control", () => {
+  const page = loadTheme();
+
+  assert.doesNotThrow(() => page.listeners.DOMContentLoaded());
+  assert.equal(page.attributes.get("data-theme-setting"), "system");
+  assert.equal(page.attributes.get("data-theme"), "light");
+});
+
+test("theme toggle still cycles light, dark, and system", () => {
+  const page = loadTheme({ hasToggle: true });
+  page.listeners.DOMContentLoaded();
+
+  page.listeners.click();
+  assert.equal(page.storage.get("theme"), "light");
+  assert.equal(page.attributes.get("data-theme"), "light");
+
+  page.listeners.click();
+  assert.equal(page.storage.get("theme"), "dark");
+  assert.equal(page.attributes.get("data-theme"), "dark");
+
+  page.listeners.click();
+  assert.equal(page.storage.get("theme"), "system");
+  assert.equal(page.attributes.get("data-theme"), "light");
+});
+
+test("system preference initializes and reapplies the computed theme", () => {
+  const page = loadTheme({ prefersDark: true });
+
+  assert.equal(page.attributes.get("data-theme"), "dark");
+  assert.doesNotThrow(() => page.mediaListeners.change({ matches: false }));
+  assert.equal(page.attributes.get("data-theme"), "dark");
+});

--- a/test/theme_test.js
+++ b/test/theme_test.js
@@ -47,7 +47,7 @@ function loadTheme({ hasToggle = false, prefersDark = false } = {}) {
   };
   const localStorage = {
     getItem(key) {
-      return storage.get(key) ?? null;
+      return storage.has(key) ? storage.get(key) : null;
     },
     setItem(key, value) {
       storage.set(key, value);


### PR DESCRIPTION
## Summary
- guard the optional homepage theme toggle before binding its click listener
- query the system theme media control once and conditionally bind its modern change listener
- add dependency-free Node regression tests for pages with/without controls, theme cycling, and OS preference

## Root cause
The homepage intentionally omits the standard header and `#light-toggle`, but `theme.js` unconditionally called `addEventListener` on that missing element during `DOMContentLoaded`, throwing and aborting the callback.

## Validation
- `node --test test/theme_test.js` (3/3 pass)
- `npx prettier assets/js/theme.js test/theme_test.js --check`
- `ruby test/cache_bust_test.rb` (6 runs, 8 assertions)
- `git diff --check`
- Jekyll production build reached notebook conversion; local host timed out while nbconvert was processing an existing notebook
- cache bust changes deterministically: production/master `theme.js?9a0c749ec5240d9cda97bc72359a72c0` -> branch `theme.js?7b060623daf8a53272fc906b81e2e0d1`

AI-assisted: implemented and tested with OpenAI Codex.
