### PR TITLE
Make homepage email non-clickable

### DIFF
--- a/_layouts/about.liquid
+++ b/_layouts/about.liquid
@@ -38,7 +38,7 @@ layout: default
           <div class="affiliation">Microsoft Research Asia</div>
           <div class="email">
             <i class="fa fa-envelope" aria-hidden="true"></i>
-            <a class="contact-email-link" href="mailto:yang.fan@acm.org">yang DOT fan AT acm DOT org</a>
+            <span class="contact-email-text">yang DOT fan AT acm DOT org</span>
           </div>
           <div class="social-networks" aria-label="Profile links">
             {% if site.work_url %}

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -32,16 +32,9 @@ $max-content-width: {{ site.max_width }};
 body.layout-about .homepage-victoria {
   .contacts .email,
   .contacts .email i,
-  .contacts .email .contact-email-link,
-  .contacts .email .contact-email-link:visited {
+  .contacts .email .contact-email-text {
     color: var(--homepage-muted);
     opacity: 1;
-  }
-
-  .contacts .email .contact-email-link:hover,
-  .contacts .email .contact-email-link:focus {
-    color: var(--homepage-accent);
-    text-decoration: underline;
   }
 
   .contacts .social-networks a,


### PR DESCRIPTION
## Summary
- replace the homepage `mailto:` anchor with a plain `<span>` containing the existing obfuscated address text
- retarget the scoped homepage color rule to the non-link class and remove link hover/focus styling
- preserve the envelope icon, alignment, contrast, and visible `yang DOT fan AT acm DOT org` text

## Verification
- `npx prettier . --check`
- production Jekyll build (homepage emitted before an unrelated notebook conversion hang)
- `npx purgecss -c purgecss.config.js`
- `ruby test/cache_bust_test.rb`
- generated `_site/index.html`: no `mailto:`, `yang.fan`, or raw address; no raw address in `<head>`/structured data; obfuscated text appears once
- Chromium and WebKit, desktop and mobile: `<span>`, no anchor ancestor, no click handler, `tabIndex === -1`, non-pointer cursor, click leaves URL unchanged, envelope retained

AI-assisted change. Not merging this PR.
