### PR TITLE
Refine desktop Blog and News typography

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -825,6 +825,28 @@ body:has(.victoria-secondary-page) > .container {
   color: inherit;
 }
 
+// Keep the denser Blog/News list scale on desktop without changing the
+// established mobile typography or individual entry pages.
+@media screen and (min-width: 769px) {
+  .victoria-news-list .victoria-news-item > h2,
+  .victoria-blog-list .victoria-blog-item > h2 {
+    font-size: 18px;
+    font-weight: 500;
+    line-height: 1.35;
+  }
+
+  .victoria-blog-list .victoria-resource-copy {
+    font-size: 15px;
+    line-height: 1.5;
+  }
+
+  .victoria-news-list .victoria-news-meta,
+  .victoria-blog-list .victoria-post-meta {
+    font-size: 12px;
+    font-weight: 500;
+  }
+}
+
 .victoria-blog-page .victoria-pagination,
 .victoria-news-page .victoria-pagination {
   margin-top: 24px;


### PR DESCRIPTION
## Summary
- apply the approved smaller/lighter 18px/500 headline scale to Blog and News lists on desktop
- set Blog excerpts to 15px/1.5 and list metadata to 12px/500
- preserve the 26px desktop page headings, existing spacing/separators, and existing mobile typography

## Verification
- `npx prettier assets/css/main.scss --check`
- `bundle exec jekyll build`
- `purgecss -c purgecss.config.js`
- Playwright at 1200px and 1440px: heading 26px; entry title 18px/500/24.3px; Blog excerpt 15px/22.5px; metadata 12px/500
- Playwright at 390px: existing title 17px/600 retained; no horizontal overflow
- verified locally on Blog pages 1-2 and News pages 1-3

AI-assisted implementation and verification.
