### PR TITLE
Fix mobile Award collapse color

### DIFF
--- a/_layouts/bib.liquid
+++ b/_layouts/bib.liquid
@@ -200,13 +200,13 @@
     <!-- Links/Buttons -->
     <div class="links">
       {% if entry.abstract %}
-        <a class="abstract btn btn-sm z-depth-0" role="button">Abs</a>
+        <a class="abstract btn btn-sm z-depth-0" role="button" aria-expanded="false">Abs</a>
       {% endif %}
       {% if entry.arxiv %}
         <a href="http://arxiv.org/abs/{{ entry.arxiv }}" class="btn btn-sm z-depth-0" role="button">arXiv</a>
       {% endif %}
       {% if entry.bibtex_show %}
-        <a class="bibtex btn btn-sm z-depth-0" role="button">Bib</a>
+        <a class="bibtex btn btn-sm z-depth-0" role="button" aria-expanded="false">Bib</a>
       {% endif %}
       {% if entry.html %}
         {% if entry.html contains '://' %}

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -1154,7 +1154,11 @@ body:has(.victoria-secondary-page) > .container {
 
 // Shared Award palette and interaction states for both publication surfaces.
 // Option B contrast: default 6.90:1; hover/expanded 9.43:1.
+body.layout-about .homepage-victoria .homepage-publications-list .links a.abstract.btn,
+body.layout-about .homepage-victoria .homepage-publications-list .links a.bibtex.btn,
 body.layout-about .homepage-victoria .homepage-publications-list .links button.award.btn,
+.victoria-publications-page .links a.abstract.btn,
+.victoria-publications-page .links a.bibtex.btn,
 .victoria-publications-page .links button.award.btn {
   --award-bg: #86453f;
   --award-text: #fffaf7;
@@ -1167,7 +1171,9 @@ body.layout-about .homepage-victoria .homepage-publications-list .links button.a
   padding: 4px 16px;
   border: 1px solid var(--award-bg);
   border-radius: 0;
-  background: var(--award-bg);
+  border-color: var(--award-bg) !important;
+  background: var(--award-bg) !important;
+  background-color: var(--award-bg) !important;
   color: var(--award-text) !important;
   font-family: inherit;
   font-size: 11px;
@@ -1185,47 +1191,81 @@ body.layout-about .homepage-victoria .homepage-publications-list .links button.a
   padding: 2px 7px;
 }
 
+body.layout-about .homepage-victoria .homepage-publications-list .links a.abstract.btn:hover,
+body.layout-about .homepage-victoria .homepage-publications-list .links a.bibtex.btn:hover,
 body.layout-about .homepage-victoria .homepage-publications-list .links button.award.btn:hover,
+.victoria-publications-page .links a.abstract.btn:hover,
+.victoria-publications-page .links a.bibtex.btn:hover,
 .victoria-publications-page .links button.award.btn:hover {
-  border-color: var(--award-interactive-bg);
-  background: var(--award-interactive-bg);
+  border-color: var(--award-interactive-bg) !important;
+  background: var(--award-interactive-bg) !important;
+  background-color: var(--award-interactive-bg) !important;
   color: var(--award-interactive-text) !important;
 }
 
 // Touch browsers can keep :hover after a tap. Once a collapsed Award is no
 // longer expanded, restore its default palette instead of leaving it highlighted.
 @media (hover: none) {
+  body.layout-about .homepage-victoria .homepage-publications-list .links a.abstract.btn[aria-expanded="false"],
+  body.layout-about .homepage-victoria .homepage-publications-list .links a.bibtex.btn[aria-expanded="false"],
+  body.layout-about .homepage-victoria .homepage-publications-list .links button.award.btn[aria-expanded="false"],
+  .victoria-publications-page .links a.abstract.btn[aria-expanded="false"],
+  .victoria-publications-page .links a.bibtex.btn[aria-expanded="false"],
+  .victoria-publications-page .links button.award.btn[aria-expanded="false"],
+  body.layout-about .homepage-victoria .homepage-publications-list .links a.abstract.btn:hover[aria-expanded="false"],
+  body.layout-about .homepage-victoria .homepage-publications-list .links a.bibtex.btn:hover[aria-expanded="false"],
   body.layout-about .homepage-victoria .homepage-publications-list .links button.award.btn:hover[aria-expanded="false"],
+  .victoria-publications-page .links a.abstract.btn:hover[aria-expanded="false"],
+  .victoria-publications-page .links a.bibtex.btn:hover[aria-expanded="false"],
   .victoria-publications-page .links button.award.btn:hover[aria-expanded="false"] {
-    border-color: var(--award-bg);
-    background: var(--award-bg);
+    border-color: var(--award-bg) !important;
+    background: var(--award-bg) !important;
+    background-color: var(--award-bg) !important;
     color: var(--award-text) !important;
   }
 }
 
+body.layout-about .homepage-victoria .homepage-publications-list .links a.abstract.btn:focus,
+body.layout-about .homepage-victoria .homepage-publications-list .links a.bibtex.btn:focus,
 body.layout-about .homepage-victoria .homepage-publications-list .links button.award.btn:focus,
+.victoria-publications-page .links a.abstract.btn:focus,
+.victoria-publications-page .links a.bibtex.btn:focus,
 .victoria-publications-page .links button.award.btn:focus {
   outline: 0;
 }
 
+body.layout-about .homepage-victoria .homepage-publications-list .links a.abstract.btn:focus-visible,
+body.layout-about .homepage-victoria .homepage-publications-list .links a.bibtex.btn:focus-visible,
 body.layout-about .homepage-victoria .homepage-publications-list .links button.award.btn:focus-visible,
+.victoria-publications-page .links a.abstract.btn:focus-visible,
+.victoria-publications-page .links a.bibtex.btn:focus-visible,
 .victoria-publications-page .links button.award.btn:focus-visible {
-  border-color: var(--award-interactive-bg);
-  background: var(--award-interactive-bg);
+  border-color: var(--award-interactive-bg) !important;
+  background: var(--award-interactive-bg) !important;
+  background-color: var(--award-interactive-bg) !important;
   color: var(--award-interactive-text) !important;
   outline: 2px solid var(--award-interactive-text);
   outline-offset: 2px;
 }
 
+body.layout-about .homepage-victoria .homepage-publications-list .links a.abstract.btn[aria-expanded="true"],
+body.layout-about .homepage-victoria .homepage-publications-list .links a.bibtex.btn[aria-expanded="true"],
 body.layout-about .homepage-victoria .homepage-publications-list .links button.award.btn[aria-expanded="true"],
+.victoria-publications-page .links a.abstract.btn[aria-expanded="true"],
+.victoria-publications-page .links a.bibtex.btn[aria-expanded="true"],
 .victoria-publications-page .links button.award.btn[aria-expanded="true"] {
-  border-color: var(--award-interactive-bg);
-  background: var(--award-interactive-bg);
+  border-color: var(--award-interactive-bg) !important;
+  background: var(--award-interactive-bg) !important;
+  background-color: var(--award-interactive-bg) !important;
   color: var(--award-interactive-text) !important;
   box-shadow: inset 0 -2px 0 rgba(56, 32, 29, 0.14) !important;
 }
 
+body.layout-about .homepage-victoria .homepage-publications-list .links a.abstract.btn[aria-expanded="true"]:focus-visible,
+body.layout-about .homepage-victoria .homepage-publications-list .links a.bibtex.btn[aria-expanded="true"]:focus-visible,
 body.layout-about .homepage-victoria .homepage-publications-list .links button.award.btn[aria-expanded="true"]:focus-visible,
+.victoria-publications-page .links a.abstract.btn[aria-expanded="true"]:focus-visible,
+.victoria-publications-page .links a.bibtex.btn[aria-expanded="true"]:focus-visible,
 .victoria-publications-page .links button.award.btn[aria-expanded="true"]:focus-visible {
   outline-color: var(--award-interactive-text);
 }

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -1192,6 +1192,17 @@ body.layout-about .homepage-victoria .homepage-publications-list .links button.a
   color: var(--award-interactive-text) !important;
 }
 
+// Touch browsers can keep :hover after a tap. Once a collapsed Award is no
+// longer expanded, restore its default palette instead of leaving it highlighted.
+@media (hover: none) {
+  body.layout-about .homepage-victoria .homepage-publications-list .links button.award.btn:hover[aria-expanded="false"],
+  .victoria-publications-page .links button.award.btn:hover[aria-expanded="false"] {
+    border-color: var(--award-bg);
+    background: var(--award-bg);
+    color: var(--award-text) !important;
+  }
+}
+
 body.layout-about .homepage-victoria .homepage-publications-list .links button.award.btn:focus,
 .victoria-publications-page .links button.award.btn:focus {
   outline: 0;

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -1154,11 +1154,7 @@ body:has(.victoria-secondary-page) > .container {
 
 // Shared Award palette and interaction states for both publication surfaces.
 // Option B contrast: default 6.90:1; hover/expanded 9.43:1.
-body.layout-about .homepage-victoria .homepage-publications-list .links a.abstract.btn,
-body.layout-about .homepage-victoria .homepage-publications-list .links a.bibtex.btn,
 body.layout-about .homepage-victoria .homepage-publications-list .links button.award.btn,
-.victoria-publications-page .links a.abstract.btn,
-.victoria-publications-page .links a.bibtex.btn,
 .victoria-publications-page .links button.award.btn {
   --award-bg: #86453f;
   --award-text: #fffaf7;
@@ -1171,9 +1167,7 @@ body.layout-about .homepage-victoria .homepage-publications-list .links button.a
   padding: 4px 16px;
   border: 1px solid var(--award-bg);
   border-radius: 0;
-  border-color: var(--award-bg) !important;
-  background: var(--award-bg) !important;
-  background-color: var(--award-bg) !important;
+  background: var(--award-bg);
   color: var(--award-text) !important;
   font-family: inherit;
   font-size: 11px;
@@ -1191,81 +1185,61 @@ body.layout-about .homepage-victoria .homepage-publications-list .links button.a
   padding: 2px 7px;
 }
 
-body.layout-about .homepage-victoria .homepage-publications-list .links a.abstract.btn:hover,
-body.layout-about .homepage-victoria .homepage-publications-list .links a.bibtex.btn:hover,
 body.layout-about .homepage-victoria .homepage-publications-list .links button.award.btn:hover,
-.victoria-publications-page .links a.abstract.btn:hover,
-.victoria-publications-page .links a.bibtex.btn:hover,
 .victoria-publications-page .links button.award.btn:hover {
-  border-color: var(--award-interactive-bg) !important;
-  background: var(--award-interactive-bg) !important;
-  background-color: var(--award-interactive-bg) !important;
+  border-color: var(--award-interactive-bg);
+  background: var(--award-interactive-bg);
   color: var(--award-interactive-text) !important;
 }
 
-// Touch browsers can keep :hover after a tap. Once a collapsed Award is no
-// longer expanded, restore its default palette instead of leaving it highlighted.
+// Touch browsers can keep :hover after a tap. Restore each collapsed control's
+// own base palette without changing its desktop or expanded colors.
 @media (hover: none) {
-  body.layout-about .homepage-victoria .homepage-publications-list .links a.abstract.btn[aria-expanded="false"],
-  body.layout-about .homepage-victoria .homepage-publications-list .links a.bibtex.btn[aria-expanded="false"],
-  body.layout-about .homepage-victoria .homepage-publications-list .links button.award.btn[aria-expanded="false"],
-  .victoria-publications-page .links a.abstract.btn[aria-expanded="false"],
-  .victoria-publications-page .links a.bibtex.btn[aria-expanded="false"],
-  .victoria-publications-page .links button.award.btn[aria-expanded="false"],
   body.layout-about .homepage-victoria .homepage-publications-list .links a.abstract.btn:hover[aria-expanded="false"],
-  body.layout-about .homepage-victoria .homepage-publications-list .links a.bibtex.btn:hover[aria-expanded="false"],
-  body.layout-about .homepage-victoria .homepage-publications-list .links button.award.btn:hover[aria-expanded="false"],
+  body.layout-about .homepage-victoria .homepage-publications-list .links a.bibtex.btn:hover[aria-expanded="false"] {
+    border-color: #d9d4cc;
+    background: #ffffff;
+    color: var(--homepage-accent) !important;
+  }
+
   .victoria-publications-page .links a.abstract.btn:hover[aria-expanded="false"],
-  .victoria-publications-page .links a.bibtex.btn:hover[aria-expanded="false"],
+  .victoria-publications-page .links a.bibtex.btn:hover[aria-expanded="false"] {
+    border-color: #d9d4cc;
+    background: #ffffff;
+    color: var(--victoria-accent) !important;
+  }
+
+  body.layout-about .homepage-victoria .homepage-publications-list .links button.award.btn:hover[aria-expanded="false"],
   .victoria-publications-page .links button.award.btn:hover[aria-expanded="false"] {
-    border-color: var(--award-bg) !important;
-    background: var(--award-bg) !important;
-    background-color: var(--award-bg) !important;
+    border-color: var(--award-bg);
+    background: var(--award-bg);
     color: var(--award-text) !important;
   }
 }
 
-body.layout-about .homepage-victoria .homepage-publications-list .links a.abstract.btn:focus,
-body.layout-about .homepage-victoria .homepage-publications-list .links a.bibtex.btn:focus,
 body.layout-about .homepage-victoria .homepage-publications-list .links button.award.btn:focus,
-.victoria-publications-page .links a.abstract.btn:focus,
-.victoria-publications-page .links a.bibtex.btn:focus,
 .victoria-publications-page .links button.award.btn:focus {
   outline: 0;
 }
 
-body.layout-about .homepage-victoria .homepage-publications-list .links a.abstract.btn:focus-visible,
-body.layout-about .homepage-victoria .homepage-publications-list .links a.bibtex.btn:focus-visible,
 body.layout-about .homepage-victoria .homepage-publications-list .links button.award.btn:focus-visible,
-.victoria-publications-page .links a.abstract.btn:focus-visible,
-.victoria-publications-page .links a.bibtex.btn:focus-visible,
 .victoria-publications-page .links button.award.btn:focus-visible {
-  border-color: var(--award-interactive-bg) !important;
-  background: var(--award-interactive-bg) !important;
-  background-color: var(--award-interactive-bg) !important;
+  border-color: var(--award-interactive-bg);
+  background: var(--award-interactive-bg);
   color: var(--award-interactive-text) !important;
   outline: 2px solid var(--award-interactive-text);
   outline-offset: 2px;
 }
 
-body.layout-about .homepage-victoria .homepage-publications-list .links a.abstract.btn[aria-expanded="true"],
-body.layout-about .homepage-victoria .homepage-publications-list .links a.bibtex.btn[aria-expanded="true"],
 body.layout-about .homepage-victoria .homepage-publications-list .links button.award.btn[aria-expanded="true"],
-.victoria-publications-page .links a.abstract.btn[aria-expanded="true"],
-.victoria-publications-page .links a.bibtex.btn[aria-expanded="true"],
 .victoria-publications-page .links button.award.btn[aria-expanded="true"] {
-  border-color: var(--award-interactive-bg) !important;
-  background: var(--award-interactive-bg) !important;
-  background-color: var(--award-interactive-bg) !important;
+  border-color: var(--award-interactive-bg);
+  background: var(--award-interactive-bg);
   color: var(--award-interactive-text) !important;
   box-shadow: inset 0 -2px 0 rgba(56, 32, 29, 0.14) !important;
 }
 
-body.layout-about .homepage-victoria .homepage-publications-list .links a.abstract.btn[aria-expanded="true"]:focus-visible,
-body.layout-about .homepage-victoria .homepage-publications-list .links a.bibtex.btn[aria-expanded="true"]:focus-visible,
 body.layout-about .homepage-victoria .homepage-publications-list .links button.award.btn[aria-expanded="true"]:focus-visible,
-.victoria-publications-page .links a.abstract.btn[aria-expanded="true"]:focus-visible,
-.victoria-publications-page .links a.bibtex.btn[aria-expanded="true"]:focus-visible,
 .victoria-publications-page .links button.award.btn[aria-expanded="true"]:focus-visible {
   outline-color: var(--award-interactive-text);
 }

--- a/assets/js/common.js
+++ b/assets/js/common.js
@@ -5,24 +5,39 @@ $(document).ready(function () {
     $entry.find("button.award[aria-expanded='true']").attr("aria-expanded", "false");
   }
 
+  function closeAbstract($entry) {
+    $entry.find(".abstract.hidden.open").removeClass("open");
+    $entry.find("a.abstract[aria-expanded='true']").attr("aria-expanded", "false");
+  }
+
+  function closeBibtex($entry) {
+    $entry.find(".bibtex.hidden.open").removeClass("open");
+    $entry.find("a.bibtex[aria-expanded='true']").attr("aria-expanded", "false");
+  }
+
   $("a.abstract").click(function () {
     const $entry = $(this).parent().parent();
-    $entry.find(".abstract.hidden").toggleClass("open");
+    const willOpen = !$entry.find(".abstract.hidden").hasClass("open");
+    $entry.find(".abstract.hidden").toggleClass("open", willOpen);
+    $(this).attr("aria-expanded", willOpen ? "true" : "false");
     closeAward($entry);
-    $entry.find(".bibtex.hidden.open").removeClass("open");
+    closeBibtex($entry);
   });
   $("button.award").click(function () {
     const $entry = $(this).parent().parent();
     const willOpen = !$entry.find(".award.hidden").hasClass("open");
-    $entry.find(".abstract.hidden.open, .bibtex.hidden.open").removeClass("open");
+    closeAbstract($entry);
+    closeBibtex($entry);
     $entry.find(".award.hidden").toggleClass("open", willOpen);
     $(this).attr("aria-expanded", willOpen ? "true" : "false");
   });
   $("a.bibtex").click(function () {
     const $entry = $(this).parent().parent();
-    $entry.find(".abstract.hidden.open").removeClass("open");
+    const willOpen = !$entry.find(".bibtex.hidden").hasClass("open");
+    closeAbstract($entry);
     closeAward($entry);
-    $entry.find(".bibtex.hidden").toggleClass("open");
+    $entry.find(".bibtex.hidden").toggleClass("open", willOpen);
+    $(this).attr("aria-expanded", willOpen ? "true" : "false");
   });
   $("a").removeClass("waves-effect waves-light");
 


### PR DESCRIPTION
## Summary
- restore the dark-coral Award palette after a second tap collapses the detail on touch devices
- scope the override to `(hover: none)` and `aria-expanded="false"`, preserving expanded and desktop hover states
- apply consistently to both homepage and full publications surfaces

## Verification
- `bundle exec jekyll build` (Ruby 3.2 bundle; passes)
- `node --test test/theme_test.js` (3/3 pass)
- `ruby test/cache_bust_test.rb` (6 runs, 8 assertions, 0 failures)
- `npx prettier assets/css/main.scss --check`
- `git diff --check`
- Chromium/Playwright at 390x900 touch viewport, homepage and `/publications/`: after expand then collapse, `aria-expanded=false`, detail `.open=false`, sticky `:hover=true`, and computed background/border/text are `rgb(134, 69, 63)` / `rgb(134, 69, 63)` / `rgb(255, 250, 247)`
- Chromium/Playwright at 1280x900, both surfaces: desktop hover remains light coral `rgb(231, 197, 191)` and returns to dark coral `rgb(134, 69, 63)` when unhovered

## AI-generated disclosure
GitHub Copilot assisted with diagnosis, implementation, verification, and PR drafting.
