### PR TITLE
Highlight publication venue abbreviations

### DIFF
--- a/_layouts/bib.liquid
+++ b/_layouts/bib.liquid
@@ -190,8 +190,11 @@
     {% endif %}
     {% assign entrytype_text = entrytype | strip_html | strip %}
     {% capture periodical %}{{ entrytype }}{% if entrytype_text != "" and entryyear != "" %}, {% endif %}{{ entrymonth }}{{ entryyear }}{% endcapture %}
-    <div class="periodical">
-      {{ periodical | strip }}
+    <div class="publication-meta">
+      {% if entry.abbr %}
+        <abbr class="publication-venue">{{ entry.abbr }}</abbr>
+      {% endif %}
+      <span class="periodical">{{ periodical | strip }}</span>
     </div>
     <div class="periodical">
       {{ entry.note | strip }}

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -1308,10 +1308,8 @@ ninja-keys::part(ninja-input-wrapper) {
   }
 }
 
-// Keep publication search hits distinct from the purple global theme while
-// matching the site's warm editorial palette. The publication surface remains
-// white across light, dark, and system theme preferences.
+// highlight-search-term
 ::highlight(search) {
-  background-color: #f7e2c4;
-  color: #5b3a23;
+  background-color: var(--global-theme-color);
+  color: var(--global-text-color);
 }

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -1308,8 +1308,10 @@ ninja-keys::part(ninja-input-wrapper) {
   }
 }
 
-// highlight-search-term
+// Keep publication search hits distinct from the purple global theme while
+// matching the site's warm editorial palette. The publication surface remains
+// white across light, dark, and system theme preferences.
 ::highlight(search) {
-  background-color: var(--global-theme-color);
-  color: var(--global-text-color);
+  background-color: #f7e2c4;
+  color: #5b3a23;
 }

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -1027,6 +1027,42 @@ body:has(.victoria-secondary-page) > .container {
   line-height: 1.45;
 }
 
+// Keep the venue legible without competing with the publication title. The
+// warm tint is derived from the page accent and remains readable on the site's
+// intentionally white editorial surface in both light and dark OS themes.
+.publication-meta {
+  display: flex;
+  min-width: 0;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 4px 7px;
+}
+
+.publication-meta .publication-venue {
+  display: inline-flex;
+  max-width: 100%;
+  padding: 1px 7px 2px;
+  border: 1px solid rgba(107, 79, 41, 0.22);
+  border-radius: 4px;
+  background: rgba(107, 79, 41, 0.09);
+  color: var(--victoria-accent, var(--homepage-accent, #6b4f29));
+  font-size: 0.78em;
+  font-weight: 700;
+  line-height: 1.35;
+  overflow-wrap: anywhere;
+  text-decoration: none;
+  white-space: normal;
+}
+
+.victoria-publications-page .publication-meta,
+body.layout-about .homepage-victoria .homepage-publications-list .publication-meta {
+  margin-top: 3px;
+}
+
+.victoria-publications-page .publication-meta .periodical {
+  min-width: 0;
+}
+
 .victoria-publications-page .author a,
 .victoria-publications-page .author > em,
 .victoria-publications-page .author .author-self,

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -1063,6 +1063,14 @@ body.layout-about .homepage-victoria .homepage-publications-list .publication-me
   min-width: 0;
 }
 
+// Keep publication search hits distinct from the purple global theme while
+// matching the site's warm editorial palette. The publication surface remains
+// white across light, dark, and system theme preferences.
+::highlight(search) {
+  background-color: #f7e2c4;
+  color: #5b3a23;
+}
+
 .victoria-publications-page .author a,
 .victoria-publications-page .author > em,
 .victoria-publications-page .author .author-self,


### PR DESCRIPTION
## Design rationale
- Surfaces the existing `abbr` value beside the venue/year metadata, where it remains scannable without competing with the publication title.
- Uses the site's warm brown accent as a subtle tinted background and border, with 700 weight, a modest 4px radius, and compact horizontal padding.
- Restyles CSS Custom Highlight API search hits from the global purple to warm apricot `#F7E2C4` with deep brown `#5B3A23` text (8.02:1 contrast), matching the editorial palette without changing search behavior.
- Flex wrapping and `overflow-wrap` accommodate both short venues (ICML) and longer abbreviations on narrow screens.
- The publication pages use an intentionally white editorial surface across OS color schemes, so both venue badges and search highlights stay consistent in light, dark, and system preferences.
- Publication data/content is unchanged.

## Changes
- `_layouts/bib.liquid`: render a semantic venue badge in publication metadata.
- `assets/css/main.scss`: add responsive badge styling and override only the search-hit foreground/background colors.

## Verification
- `ruby test/cache_bust_test.rb` (6 runs, 8 assertions)
- `node test/theme_test.js` (3/3 passing)
- `npx prettier --check _sass/_base.scss _layouts/bib.liquid assets/css/main.scss`
- `JEKYLL_ENV=production bundle exec jekyll build`
- `git diff --check`
- Deployed-preview Playwright/Chromium search for `system`: 45 visible publications and 98 highlight ranges on desktop (1440px) and mobile (390px); no horizontal overflow; text selection returns `System`; venue badges remain present (104).
- Dark-system emulation retains the intentional white Publications surface and the same warm highlight palette.
- GitHub Actions: branch preview, PR build, and Prettier all pass.

## AI disclosure
This design and implementation were created with AI assistance and reviewed through formatting, source checks, CI, contrast calculation, and desktop/mobile browser interaction verification.