### PR TITLE
Automate homepage footer update date

### DIFF
--- a/.github/workflows/branch-preview.yml
+++ b/.github/workflows/branch-preview.yml
@@ -64,6 +64,7 @@ jobs:
         run: |
           pip3 install --upgrade jupyter
           ruby test/cache_bust_test.rb
+          ruby test/repository_last_updated_test.rb
           export JEKYLL_ENV=production
           bundle exec jekyll build
       - name: Purge unused CSS 🧹

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -88,6 +88,7 @@ jobs:
         run: |
           pip3 install --upgrade jupyter
           ruby test/cache_bust_test.rb
+          ruby test/repository_last_updated_test.rb
           export JEKYLL_ENV=production
           bundle exec jekyll build
       - name: Purge unused CSS 🧹

--- a/_layouts/about.liquid
+++ b/_layouts/about.liquid
@@ -144,5 +144,5 @@ layout: default
     </div>
   </div>
 
-  <div class="homepage-footer">© All right reserved. Last updated on July 10, 2026</div>
+  <div class="homepage-footer">© All right reserved. Last updated on {{ site.repository_last_updated_at | date: '%B %-d, %Y' }}</div>
 </div>

--- a/_plugins/repository-last-updated.rb
+++ b/_plugins/repository-last-updated.rb
@@ -1,0 +1,19 @@
+# Derive the site's update date from the commit being built, not the build clock.
+require 'open3'
+
+module Jekyll
+  class RepositoryLastUpdatedGenerator < Generator
+    priority :highest
+
+    def generate(site)
+      timestamp, status = Open3.capture2('git', 'log', '-1', '--format=%cI', 'HEAD', chdir: site.source)
+      timestamp = timestamp.strip
+
+      unless status.success? && !timestamp.empty?
+        raise 'Could not determine the repository HEAD commit date'
+      end
+
+      site.config['repository_last_updated_at'] = timestamp
+    end
+  end
+end

--- a/test/repository_last_updated_test.rb
+++ b/test/repository_last_updated_test.rb
@@ -1,0 +1,50 @@
+# AI-generated regression coverage for the build-time repository update date.
+require 'fileutils'
+require 'minitest/autorun'
+require 'tmpdir'
+
+module Jekyll
+  class Generator
+    def self.priority(_priority); end
+  end
+end
+
+require_relative '../_plugins/repository-last-updated'
+
+class RepositoryLastUpdatedGeneratorTest < Minitest::Test
+  Site = Struct.new(:source, :config)
+
+  def setup
+    @tmpdir = Dir.mktmpdir('repository-last-updated-test')
+    git('init', '--quiet')
+    git('config', 'user.name', 'Test User')
+    git('config', 'user.email', 'test@example.com')
+    File.write(File.join(@tmpdir, 'index.md'), 'test')
+    git('add', 'index.md')
+    git(
+      'commit', '--quiet', '-m', 'Test commit',
+      env: {
+        'GIT_AUTHOR_DATE' => '2026-07-12T09:10:11Z',
+        'GIT_COMMITTER_DATE' => '2026-07-13T12:35:52+08:00'
+      }
+    )
+  end
+
+  def teardown
+    FileUtils.remove_entry(@tmpdir)
+  end
+
+  def test_exposes_head_committer_timestamp_to_liquid
+    site = Site.new(@tmpdir, {})
+
+    Jekyll::RepositoryLastUpdatedGenerator.new.generate(site)
+
+    assert_equal '2026-07-13T12:35:52+08:00', site.config['repository_last_updated_at']
+  end
+
+  private
+
+  def git(*arguments, env: {})
+    system(env, 'git', *arguments, chdir: @tmpdir, exception: true)
+  end
+end


### PR DESCRIPTION
## Summary
- derive the homepage footer date at Jekyll build time from the checked-out repository HEAD commit's committer timestamp
- render that value in the existing `Last updated on …` wording instead of a hard-coded date
- cover timestamp extraction with a focused regression test and run it in both production and branch-preview builds

## Implementation
A highest-priority Jekyll generator runs `git log -1 --format=%cI HEAD` in the site source and exposes the result as `site.repository_last_updated_at`. The homepage Liquid layout formats that timestamp as the existing human-readable month/day/year date. This makes merged changes and redeploys reflect the effective commit rather than the wall-clock build time, with no client-side JavaScript.

## Verification
- `ruby test/repository_last_updated_test.rb` — 1 run, 1 assertion, pass
- `ruby test/cache_bust_test.rb` — 6 runs, 8 assertions, pass
- `npx prettier . --check` — pass
- `JEKYLL_ENV=production bundle exec jekyll build` — pass
- inspected generated `_site/index.html`; it rendered `Last updated on July 13, 2026`, matching the source HEAD commit date used by that build

> This change and PR description were AI-generated under human direction and review.
