### PR TITLE
Add terminal period to homepage footer

### DIFF
--- a/_layouts/about.liquid
+++ b/_layouts/about.liquid
@@ -144,5 +144,5 @@ layout: default
     </div>
   </div>
 
-  <div class="homepage-footer">© All right reserved. Last updated on {{ site.repository_last_updated_at | date: '%B %-d, %Y' }}</div>
+  <div class="homepage-footer">© All right reserved. Last updated on {{ site.repository_last_updated_at | date: '%B %-d, %Y' }}.</div>
 </div>

--- a/test/repository_last_updated_test.rb
+++ b/test/repository_last_updated_test.rb
@@ -42,6 +42,12 @@ class RepositoryLastUpdatedGeneratorTest < Minitest::Test
     assert_equal '2026-07-13T12:35:52+08:00', site.config['repository_last_updated_at']
   end
 
+  def test_homepage_footer_terminates_repository_update_date_with_period
+    layout = File.read(File.expand_path('../_layouts/about.liquid', __dir__))
+
+    assert_includes layout, "{{ site.repository_last_updated_at | date: '%B %-d, %Y' }}.</div>"
+  end
+
   private
 
   def git(*arguments, env: {})


### PR DESCRIPTION
## Summary
- add the missing terminal period after the homepage footer's automatic repository update date
- add focused regression coverage for the punctuation
- preserve the existing wording and commit-date-derived date behavior

## Testing
- `bundle exec ruby test/*_test.rb` (each test file)
- `node test/theme_test.js`
- `npx prettier --check _layouts/about.liquid test/repository_last_updated_test.rb`
- `JEKYLL_ENV=production bundle exec jekyll build`
- inspected `_site/index.html`: `© All right reserved. Last updated on July 14, 2026.`
- `git diff --check`

## AI disclosure
This PR was generated with AI assistance. The change, regression test, and verification steps were performed by an AI coding assistant at the request of the repository owner.